### PR TITLE
Use pdb and state paths provided in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ gmon.out
 *.log
 *.state
 *.results
+*.config
+*.pdb
 
 OutputLog
 

--- a/src/Metropolis/SerialSim/SerialCalcs.cpp
+++ b/src/Metropolis/SerialSim/SerialCalcs.cpp
@@ -17,13 +17,15 @@
 
 using namespace std;
 
-Box* SerialCalcs::createBox(std::string inputPath, InputFileType inputType, long* startStep, long* steps) {
+Box* SerialCalcs::createBox(SimulationArgs& simArgs, long* startStep, long* steps) {
 	SerialBox* box = new SerialBox();
-	if (!loadBoxData(inputPath, inputType, box, startStep, steps)) {
-		if (inputType != InputFile::Unknown) {
-			std::cerr << "Error: Could not build from file: " << inputPath << std::endl;
+	if (!loadBoxData(simArgs, box, startStep, steps)) {
+		if (simArgs.fileType != InputFile::Unknown) {
+			std::cerr << "Error: Could not build from file: " << simArgs.filePath
+								<< std::endl;
 		} else {
-			std::cerr << "Error: Can not build environment with unknown file: " << inputPath << std::endl;
+			std::cerr << "Error: Can not build environment with unknown file: " 
+								<< simArgs.filePath << std::endl;
 		}
 		return NULL;
 	}

--- a/src/Metropolis/SerialSim/SerialCalcs.h
+++ b/src/Metropolis/SerialSim/SerialCalcs.h
@@ -30,7 +30,7 @@ namespace SerialCalcs {
 	 *   		but it was placed here due to time constraints.
 	 *   		TODO for future group.
    */
-	Box* createBox(std::string inputPath, InputFileType inputType, long* startStep, long* steps);
+	Box* createBox(SimulationArgs& simArgs, long* startStep, long* steps);
 
 	/**
 	 * Calculates the long-range correction energy value for molecules outside the cutoff.

--- a/src/Metropolis/Simulation.cpp
+++ b/src/Metropolis/Simulation.cpp
@@ -44,7 +44,7 @@ Simulation::Simulation(SimulationArgs simArgs) {
 	args = simArgs;
 	stepStart = 0;
 
-	box = SerialCalcs::createBox(args.filePath, args.fileType, &stepStart, &simSteps);
+	box = SerialCalcs::createBox(args, &stepStart, &simSteps);
 	if (box == NULL) {
 		std::cerr << "Error: Unable to initialize simulation Box" << std::endl;
 		exit(EXIT_FAILURE);
@@ -328,7 +328,11 @@ void Simulation::run() {
 
 void Simulation::saveState(const std::string& baseFileName, int simStep, const SimBox* sb) {
 	StateScanner statescan = StateScanner("");
-	std::string stateOutputPath = baseFileName;
+	std::string stateOutputPath;
+	if (!args.stateOutputPath.empty()) {
+		stateOutputPath = args.stateOutputPath + "/";
+	}
+	stateOutputPath.append(baseFileName);
 	std::string stepCount;
 
 	if (!toString<int>(simStep, stepCount))
@@ -343,13 +347,18 @@ void Simulation::saveState(const std::string& baseFileName, int simStep, const S
 	statescan.outputState(box->getEnvironment(), box->getMolecules(), box->getMoleculeCount(), simStep, stateOutputPath, sb->atomCoordinates);
 }
 
-int Simulation::writePDB(Environment sourceEnvironment, Molecule * sourceMoleculeCollection, SimBox* sb) {
+int Simulation::writePDB(Environment sourceEnvironment, Molecule* sourceMoleculeCollection, SimBox* sb) {
   std::string pdbName;
 
-  if (args.simulationName.empty())
-    pdbName = RESULTS_FILE_DEFAULT;
-  else
-    pdbName = args.simulationName;
+	if (!args.pdbOutputPath.empty()) {
+		pdbName = args.pdbOutputPath;
+		pdbName.append("/");
+	}
+	if (!args.simulationName.empty()) {
+    pdbName.append(args.simulationName);
+	} else {
+    pdbName.append(RESULTS_FILE_DEFAULT);
+	}
 
   pdbName.append(".pdb");
   std::ofstream pdbFile;

--- a/src/Metropolis/SimulationArgs.h
+++ b/src/Metropolis/SimulationArgs.h
@@ -97,6 +97,12 @@ struct SimulationArgs
 	///    at the very end of the simulation (which is the default
 	///    behavior with no interval specified).
 	int stateInterval;
+
+	/// Filepath to output PDB data
+	std::string pdbOutputPath;
+
+	/// Filepath to output simulation state data
+	std::string stateOutputPath;
 };
 
 #endif

--- a/src/Metropolis/Utilities/FileUtilities.cpp
+++ b/src/Metropolis/Utilities/FileUtilities.cpp
@@ -15,7 +15,7 @@ using std::ifstream;
 
 #define DEFAULT_STEP_COUNT 100
 
-bool loadBoxData(string inputPath, InputFileType inputType, Box* box, long* startStep, long* steps) {
+bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep, long* steps) {
 
 	if (box == NULL) {			// If box is null, print an error and return.
 		std::cerr << "Error: loadBoxData(): Box is NULL" << std::endl;
@@ -27,14 +27,16 @@ bool loadBoxData(string inputPath, InputFileType inputType, Box* box, long* star
 
 	SBScanner sb_scanner;
 
-  if (inputType == InputFile::Configuration) {	// Build from config/z-matrix.
+  if (simArgs.fileType == InputFile::Configuration) {	// Build from config/z-matrix.
 
 	  // Reading in config information from config file.
 		ConfigScanner config_scanner = ConfigScanner();
-    if (!config_scanner.readInConfig(inputPath)) {
+    if (!config_scanner.readInConfig(simArgs.filePath)) {
   		std::cerr << "Error: loadBoxData(): Could not read config file" << std::endl;
       return false;
     }
+		simArgs.pdbOutputPath = config_scanner.getPdbOutputPath();
+		simArgs.stateOutputPath = config_scanner.getStateOutputPath();
 
 		// Getting bond and angle data from oplsaa.sb file.
 	  sb_scanner = SBScanner();
@@ -90,10 +92,10 @@ bool loadBoxData(string inputPath, InputFileType inputType, Box* box, long* star
 
   	return true;
 
-  } else if (inputType == InputFile::State) {		// Build from state file.
+  } else if (simArgs.fileType == InputFile::State) {		// Build from state file.
 
 		// Instantiate a state scanner and read in the environment.
-		StateScanner state_scanner = StateScanner(inputPath);
+		StateScanner state_scanner = StateScanner(simArgs.filePath);
     enviro = state_scanner.readInEnvironment();
 
 		// Validate the environment

--- a/src/Metropolis/Utilities/FileUtilities.h
+++ b/src/Metropolis/Utilities/FileUtilities.h
@@ -621,7 +621,7 @@ class StateScanner
 * @returns: returns TRUE if completed successfully, or FALSE if there was a show-stopping error
 *		for which you should do halt the simulation
 */
-bool loadBoxData(string inputPath, InputFileType inputType, Box* box, long* startStep, long* steps);
+bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep, long* steps);
 
 
 /*************************


### PR DESCRIPTION
Fixes #29 

The simulation was outputting the pdb and state files in the current working directory, despite the config file. This fixes it to use the path specified in the config file, and falls back on the working directory if no path was specified.

*Note:* The config file expects a directory, not a specific file name. The default file names (usually the simulation name if it has one) is still used.