### PR TITLE
Update example configs and make language clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ Line numbers are important
 [17]    #line 17 is a comment and is ignored.
 [18]    <path to the state input file; overrides z-matrix setting if present>
 [19]    #line 19 is a comment and is ignored.
-[20]    <path to the state output file>
+[20]    <path to the directory for state output (empty is current directory)>
 [21]    #line 21 is a comment and is ignored.
-[22]    <path to the pdb output file>
+[22]    <path to the directory for pdb output (empty is current directory>
 [23]    #line 23 is a comment and is ignored.
 [24]    <nonbonded cutoff distance in angstroms>
 [25]    #line 25 is a comment and is ignored.
@@ -195,6 +195,8 @@ Line numbers are important
 [28]    <random number seed input as integer value>
 [29]    #line 29 is a comment and is ignored.
 [30]    <primary atom index array to be used during cutoff as integer indexes of z-matrix atom in molecule, comma separated, starting from zero>
+[31]    #line 31 is a comment and is ignored.
+[32]    <simulation name>
 ```
 
 **Contributing Authors**: Guillermo Aguirre, Scott Aldige, James Bass, Jared Brown, Matt Campbell, William Champion, Nathan Coleman, Yitong Dai, Seth Denney, Matthew Hardwick, Andrew Lewis, Alexander Luchs, Jennifer Lynch, Tavis Maclellan, Joshua Mosby, Jeffrey Overbey, Mitchell Price, Robert Sanek, Jonathan Sligh, Riley Spahn, Kalan Stowe, Ashley Tolbert, Albert Wallace, Jay Whaley, Seth Wooten, James Young, Francis Zayek, Xiao (David) Zhang, and Orlando Acevedo*

--- a/resources/demo.config
+++ b/resources/demo.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/bossFiles/mesh.z
 #path to state input
 
-#path to state output
-demo.state
-#pdb output path
-demo.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 9.0
 #max rotation
@@ -28,3 +28,5 @@ demo.pdb
 12345
 #Primary Atom Index
 5
+#name of the simulation
+demo

--- a/resources/demoConfiguration.txt
+++ b/resources/demoConfiguration.txt
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/bossFiles/mesh.z
 #path to state input
 
-#path to state output
-stateOutput
-#pdb output path
-pdbOutput.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 9.0
 #max rotation
@@ -28,3 +28,5 @@ pdbOutput.pdb
 12345
 #Primary Atom Index
 5
+#name of the simulation
+demoConfiguraion

--- a/resources/demo_multi.config
+++ b/resources/demo_multi.config
@@ -16,10 +16,10 @@
 ../resources/bossFiles/adesucH.z
 #path to state input
 
-#path to state output
-stateOutput
-#pdb output path
-pdbOutput.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 9.0
 #max rotation
@@ -28,3 +28,5 @@ pdbOutput.pdb
 12345
 #Primary Atom Index
 [3,2],[3,5]
+#name of the simulation
+demo_multi

--- a/resources/exampleFiles/indole267.config
+++ b/resources/exampleFiles/indole267.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/indole.z
 #path to state input
 
-#path to state output
-indole267.state
-#pdb output path
-indole267.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 12.0
 #max rotation
@@ -28,3 +28,5 @@ indole267.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+indole267

--- a/resources/exampleFiles/indole4000.config
+++ b/resources/exampleFiles/indole4000.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/indole.z
 #path to state input
 
-#path to state output
-indole4000.state
-#pdb output path
-indole4000.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 12.0
 #max rotation
@@ -28,3 +28,5 @@ indole4000.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+indole4000

--- a/resources/exampleFiles/indole5324.config
+++ b/resources/exampleFiles/indole5324.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/indole.z
 #path to state input
 
-#path to state output
-indole5324.state
-#pdb output path
-indole5324.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 12.0
 #max rotation
@@ -28,3 +28,5 @@ indole5324.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+indole5324

--- a/resources/exampleFiles/meoh4000.config
+++ b/resources/exampleFiles/meoh4000.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/meoh.z
 #path to state input
 
-#path to state output
-meoh4000.state
-#pdb output path
-meoh4000.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 11.0
 #max rotation
@@ -28,3 +28,5 @@ meoh4000.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+meoh4000

--- a/resources/exampleFiles/meoh500.config
+++ b/resources/exampleFiles/meoh500.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/meoh.z
 #path to state input
 
-#path to state output
-meoh500.state
-#pdb output path
-meoh500.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 11.0
 #max rotation
@@ -28,3 +28,5 @@ meoh500.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+meoh500

--- a/resources/exampleFiles/meoh8788.config
+++ b/resources/exampleFiles/meoh8788.config
@@ -16,10 +16,10 @@ resources/bossFiles/oplsaa.par
 resources/exampleFiles/meoh.z
 #path to state input
 
-#path to state output
-meoh8788.state
-#pdb output path
-meoh8788.pdb
+#path to state output directory
+
+#path to pdb output directory
+
 #cutoff distance in angstroms
 11.0
 #max rotation
@@ -28,3 +28,5 @@ meoh8788.pdb
 12345
 #Primary Atom Index
 1
+#name of the simulation
+meoh8788

--- a/src/Metropolis/SimulationArgs.h
+++ b/src/Metropolis/SimulationArgs.h
@@ -98,10 +98,10 @@ struct SimulationArgs
 	///    behavior with no interval specified).
 	int stateInterval;
 
-	/// Filepath to output PDB data
+	/// Path to directory for PDB output data
 	std::string pdbOutputPath;
 
-	/// Filepath to output simulation state data
+	/// Path to directory for simulation state data
 	std::string stateOutputPath;
 };
 

--- a/src/Metropolis/Utilities/ConfigScanner.cpp
+++ b/src/Metropolis/Utilities/ConfigScanner.cpp
@@ -186,6 +186,10 @@ bool ConfigScanner::readInConfig(string configpath) {
 						return false;
 					}
           break;
+		case 32: // Simulation Name
+		  if (line.length() > 0) {
+		  	simName = line;
+		  }
       }
 
 			currentLine++;
@@ -269,4 +273,8 @@ string ConfigScanner::getStateOutputPath() {
 
 string ConfigScanner::getPdbOutputPath() {
   return pdbOutputPath;
+}
+
+string ConfigScanner::getSimulationName() {
+  return simName;
 }

--- a/src/Metropolis/Utilities/FileUtilities.cpp
+++ b/src/Metropolis/Utilities/FileUtilities.cpp
@@ -35,8 +35,12 @@ bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep, long* steps
   		std::cerr << "Error: loadBoxData(): Could not read config file" << std::endl;
       return false;
     }
-		simArgs.pdbOutputPath = config_scanner.getPdbOutputPath();
-		simArgs.stateOutputPath = config_scanner.getStateOutputPath();
+	simArgs.pdbOutputPath = config_scanner.getPdbOutputPath();
+	simArgs.stateOutputPath = config_scanner.getStateOutputPath();
+	if (!config_scanner.getSimulationName().empty() &&
+			simArgs.simulationName.empty()) {
+		simArgs.simulationName = config_scanner.getSimulationName();
+	}
 
 		// Getting bond and angle data from oplsaa.sb file.
 	  sb_scanner = SBScanner();

--- a/src/Metropolis/Utilities/FileUtilities.h
+++ b/src/Metropolis/Utilities/FileUtilities.h
@@ -119,6 +119,10 @@ class SBScanner {
 class ConfigScanner
 {
     private:
+		/**
+		 * The name of the simulation being run.
+		 */
+		string simName;
         /**
           The environment used in the simulation.
         */
@@ -214,6 +218,12 @@ class ConfigScanner
           @return - returns the path to the pdb output file(s) for the simulation.
         */
         string getPdbOutputPath();
+		
+		/**
+		 * @return - returns the simulation name
+		 */
+		string getSimulationName();
+
         /**
           @return getSteps - returns the nonbonded cutoff in the simulation.
         */

--- a/test/unittests/MultipleSolvents/indole4000Tests/indole4000-1MPI.config
+++ b/test/unittests/MultipleSolvents/indole4000Tests/indole4000-1MPI.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.06
+0.06
 #number of steps
 100000
 #number of molecules
 4000
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/indole4000Tests/indole.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/indole4000Tests/indole.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/indole4000Tests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/indole4000Tests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/indole4000Tests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/indole4000Tests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/indole4000Tests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/indole4000Tests
 #cutoff distance in angstroms
-12.0
+12
 #max rotation
-6.0
+6
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone1MPI.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone1MPI.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone2MPI.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone2MPI.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneMulSolvent.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneMulSolvent.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneMulSolventMPI.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneMulSolventMPI.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneSingleMultipleIndexes.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneSingleMultipleIndexes.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneSingleMultipleIndexes2.config
+++ b/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimoneSingleMultipleIndexes2.config
@@ -5,25 +5,25 @@
 #temperature in Kelvin
 298.15
 #max translation
-.12
+0.12
 #number of steps
 100000
 #number of molecules
 256
-#path to opls.par file
-/home/compchem/git/Francis/MCGPU/resources/bossFiles/oplsaa.par
+#path to opla.par file
+/home/blm0026/MCGPU//resources/bossFiles/oplsaa.par
 #path to z matrix file
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests/t3pdimone.z
 #path to state input
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#path to state output
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
-#pdb output path
-/home/compchem/git/Francis/MCGPU/test/unittests/MultipleSolvents/t3pdimoneTests
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to state output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
+#path to pdb output directory
+/home/blm0026/MCGPU//test/unittests/MultipleSolvents/t3pdimoneTests
 #cutoff distance in angstroms
-11.0
+11
 #max rotation
-12.0
+12
 #Random Seed Input
 12345
 #Primary Atom Index

--- a/test/unittests/TestUtil.cpp
+++ b/test/unittests/TestUtil.cpp
@@ -26,9 +26,9 @@ void createConfigFile(std::string MCGPU, std::string fileName, std::string prima
 		<< MCGPU << settings.z_matrix_file << std::endl
 		<< "#path to state input\n"
 		<< MCGPU << settings.working_path << std::endl
-        << "#path to state output\n"
+        << "#path to state output directory\n"
         << MCGPU << settings.working_path << std::endl
-        << "#pdb output path\n"
+        << "#path to pdb output directory\n"
         << MCGPU << settings.working_path << std::endl
         << "#cutoff distance in angstroms\n"
         << settings.cutoffDistance << std::endl


### PR DESCRIPTION
**Changes**
- Example config files and readme now more clearly state that the pdb and state output fields are *directories*
- Added a "simulation name" field to the config file
  - I wasn't completely sure about this, but it seemed reasonable. The pdb and state output files will use the simulation name if one is available.
  - This field is overridden by the command line args, so is backwards-compatible