### PR TITLE
Add GCC compatibility (serial calculations only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ make
 make BUILD=debug
 ```
 
+*Note*: MCGPU can also be compiled with GCC, though it doesn't support GPU
+offloading and is therefore substantially slower. To use GCC, compile with
+
+```
+make CC=g++
+```
+
+If you compile with GCC, you **cannot** run in parallel mode.
+
 ##Run
 ###To Run a Simulation on a Local Machine:
 ```

--- a/src/Applications/Application.cpp
+++ b/src/Applications/Application.cpp
@@ -12,7 +12,10 @@
 #include "Application.h"
 #include <iostream>
 #include <fstream>
+
+#ifdef _OPENACC
 #include <openacc.h>
+#endif
 
 
 int metrosim::run(int argc, char** argv) {
@@ -22,44 +25,55 @@ int metrosim::run(int argc, char** argv) {
 		exit(EXIT_FAILURE);
 	}
 
+#ifdef _OPENACC
 	int numDevices = acc_get_num_devices(acc_device_nvidia);
 
 	// Ensure args.simulationMode is either Serial or Parallel
 	if (args.simulationMode == SimulationMode::Default) {
 		if (numDevices < 1) {
-			fprintf(stdout, "No CUDA devices found; defaulting to CPU execution.\n");
+			fprintf(stdout, "No GPU devices found; defaulting to CPU "
+                            "execution.\n");
 			args.simulationMode = SimulationMode::Serial;
 		} else {
-			fprintf(stdout, "%d CUDA device(s) found; running on GPU.\n", numDevices);
+			fprintf(stdout, "%d GPU device(s) found; running on GPU.\n",
+                    numDevices);
 			args.simulationMode = SimulationMode::Parallel;
 		}
 	}
 
-	bool parallelMode = (args.simulationMode == SimulationMode::Parallel);
+    if (args.simulationMode == SimulationMode::Parallel) {
+        if (numDevices == 0) {
+            fprintf(stdout, "ERROR: Cannot find suitable GPU!\n");
+            exit(EXIT_FAILURE);
+        }
 
-	if (parallelMode) {
-		if (numDevices == 0) {
-			fprintf(stdout, "ERROR: Cannot find suitable GPU!\n");
-			exit(EXIT_FAILURE);
-		}
-		acc_init(acc_device_nvidia);
-		acc_set_device_type(acc_device_nvidia);
-	}
+        // Implicitly sets the device
+        acc_init(acc_device_nvidia);
+    }
 
-	if (parallelMode) {
-		fprintf(stdout, "Beginning simulation using GPU...\n");
-	} else {
+#else
+    // Without OpenACC, only serial calculations are supported
+    if (args.simulationMode == SimulationMode::Parallel) {
+        fprintf(stdout, "Must compile with OpenACC capability to run in "
+                "parallel mode.\n");
+        exit(EXIT_FAILURE);
+    } else {
+        args.simulationMode = SimulationMode::Serial;
 		fprintf(stdout, "Beginning simulation using CPU...\n");
-	}
+    }
+#endif
 
 	Simulation sim = Simulation(args);
 	sim.run();
 
 	fprintf(stdout, "Finishing simulation...\n\n");
 
-	if (parallelMode) {
+// Shutdown the device if we were using the GPU
+#ifdef _OPENACC
+	if (args.simulationMode == SimulationMode::Parallel) {
 		acc_shutdown(acc_device_nvidia);
 	}
+#endif
 
 	exit(EXIT_SUCCESS);
 }

--- a/src/Applications/CommandParsing.h
+++ b/src/Applications/CommandParsing.h
@@ -15,7 +15,7 @@
 #include "Metropolis/SimulationArgs.h"
 
 #ifndef APP_NAME
-#define APP_NAME "metrosim"		 *< The executable name of the application.
+#define APP_NAME "metrosim"    *< The executable name of the application.
 #endif
 
 #define DEFAULT_STATUS_INTERVAL 1000

--- a/src/Metropolis/SimBox.cpp
+++ b/src/Metropolis/SimBox.cpp
@@ -1,6 +1,9 @@
+#ifdef _OPENACC
+#include <openacc.h>
+#endif
+
 #include "SimBox.h"
 #include "GPUCopy.h"
-#include <openacc.h>
 #include "SimCalcs.h"
 
 void SimBox::keepMoleculeInBox(int molIdx, Real** aCoords, int** molData, int* pIdxes, Real* bSize) {

--- a/src/Metropolis/Simulation.cpp
+++ b/src/Metropolis/Simulation.cpp
@@ -30,7 +30,6 @@
 #include "SerialSim/SerialBox.h"
 #include "SerialSim/SerialCalcs.h"
 #include "SerialSim/NeighborList.h"
-//#include "ParallelSim/ParallelCalcs.h"
 #include "Utilities/FileUtilities.h"
 #include "SimBox.h"
 #include "SimBoxBuilder.h"
@@ -126,8 +125,8 @@ void Simulation::run() {
 
         bool parallel = args.simulationMode == SimulationMode::Parallel;
 	SimBox* sb = builder.build(box);
-	GPUCopy::copyIn(sb);
 	GPUCopy::setParallel(parallel);
+	GPUCopy::copyIn(sb);
 	SimCalcs::setSB(sb);
 	//Calculate original starting energy for the entire system
 	if (oldEnergy == 0) {


### PR DESCRIPTION
The project can now be compiled with standard GCC. Compiling with
GCC limits execution to serial mode, since OpenACC and GPU offloading
are not really supported.

To utilize GCC, compile with

`$ make CC=g++`

OpenACC-specific code was guarded by the undefined `_OPENACC` macro
per the OpenACC standard.