### PR TITLE
Proximity matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,39 +177,56 @@ Command-line options override values given in this file. An example
 configuration file is shown below.
 
 ```
+# Name for the simulation
+sim-name=MyTestSimulation
+
 # The dimensions of the periodic simulation box (in angrstroms)
 x=55
 y=55
 z=55
+
 # Temperature (in Kelvin)
 temp=298.15
+
 # Maximum tranlsation for a molecule during the simulation
 max-translation=0.15
+
 # Number of steps to run in the simulation
 steps=1000
+
 # Number of molecules
 molecules=5120
+
 # Path to opla.par file
 opla.par=/absolute/path/to/oplsaa.par
+
 # Path to z-matrix file
 z-matrix=/aboslute/path/to/matrix.z
+
 # Path to input state *directory*
 state-input=/absolute/path/to/input/dir
+
 # Path to state output *directory*
 state-output=/absolute/path/to/output/dir
+
 # Path to pdb output *directory*
 pdb-output=/absolute/path/to/output/dir
+
 # Cutoff distance (in angstroms)
 cutoff=25
+
 # Maximum rotation of any particle
 max-rotation=15
+
 # Seed for random generator
 random-seed=12345
+
 # Primary atom index (integer indexes of z-matrix atom in molecule, comma
 # separated, starting from zero)
 primary-atom=1
-# Name for the simulation
-sim-name=MyTestSimulation
+
+# Strategy for energy calculations
+strategy=brute-force
 ```
 
 The order of the attributes is not significant. Comments can begin with `#` or

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ When using multiple solvents, the primary index array (Configuration File line 3
  * `--neighbor <interval> (-l)`: Specifies to use the neighborlist structure for molecular organization. interval is optional and refers to how many steps between updating the neighborlist (default is 100).
  * `--status-interval <interval> (-i)`: Specifies the number of simulation steps between status updates.
  * `--state-interval <interval> (-I)`: Specifies the number of simulation steps between state file snapshots of the current simulation run.
+ * `--strategy <strategy-name> (-S)`: Specifies the energy calculation strategy to utilize. Current options include `brute-force` and `proximity-matrix`
 
 To view documentation for all command-line flags available, use the --help flag:
 ```

--- a/src/Applications/CommandParsing.cpp
+++ b/src/Applications/CommandParsing.cpp
@@ -209,7 +209,7 @@ bool parseCommandLine(CommandParameters* params, SimulationArgs* args) {
 
   // Assign the simulation strategy type
   if (!params->simStrategy.empty()) {
-    args->strategy = Strategy::getStrategy(params->simStrategy);
+    args->strategy = Strategy::fromString(params->simStrategy);
     if (args->strategy == Strategy::Unknown) {
       std::cerr << APP_NAME << ": Unknown energy calculation strategy "
                 << "specified" << std::endl;
@@ -339,6 +339,11 @@ void printHelpScreen() {
           "\tThe filename for the saved state files will be the simulation\n"
           "\tname with the current step number appended at the end:\n\n"
           "\t\t<simulation-name>_<step-num>.state\n\n";
+
+  cout << "--strategy <strategy-name>\t(-S)\n"
+          "\tSpecifies the strategy to be used by the simulation for energy\n"
+          "\tcalulations. Options include 'brute-force' and\n"
+          "\t'proximity-matrix'\n\n";
 
   cout << "Generic Tool Options\n"
           "=====================\n\n";

--- a/src/Applications/CommandParsing.cpp
+++ b/src/Applications/CommandParsing.cpp
@@ -21,321 +21,348 @@ using std::string;
 #define LONG_NAME 400
 
 bool getCommands(int argc, char** argv, SimulationArgs* args) {
-	CommandParameters params = CommandParameters();
+  CommandParameters params = CommandParameters();
 
-	if (!readCommandLine(argc, argv, &params)) {
-		return false;	// Incorrect syntax for command line input
-	} else if (!parseCommandLine(&params, args)) {
-		return false;	// Incorrect semantics of command line input
-	} else {
-		return true;
-	}
+  if (!readCommandLine(argc, argv, &params)) {
+    return false; // Incorrect syntax for command line input
+  } else if (!parseCommandLine(&params, args)) {
+    return false; // Incorrect semantics of command line input
+  } else {
+    return true;
+  }
 }
 
 bool readCommandLine(int argc, char** argv, CommandParameters* params) {
-	// The getopt variables
-	int getopt_ret, long_index;
+  // The getopt variables
+  int getopt_ret, long_index;
 
-	// Disable default getopt error messages. We will handle errors manually
-	opterr = 0;
+  // Disable default getopt error messages. We will handle errors manually
+  opterr = 0;
 
-	// The short options recognized by the program
-	const char* short_options = ":i:I:n:i:sphVkl:";
+  // The short options recognized by the program
+  const char* short_options = ":i:I:n:i:sphVkl:S:";
 
-	// The long options recognized by the program
-	struct option long_options[] = {
-		{"status-interval", 	required_argument, 	0, 	'i'},
-		{"state-interval",		required_argument,	0,	'I'},
-		{"steps",				required_argument,	0,	'n'},
-		{"serial", 				no_argument, 		0, 	's'},
-		{"parallel", 			no_argument, 		0, 	'p'},
-		{"help", 				no_argument, 		0, 	'h'},
-		{"version",				no_argument,		0,	'V'},
-		{"verbose",				no_argument,		0,	'k'},
-		{"neighbor",			required_argument,	0,	'l'},
-		{"name",				required_argument,	0,	LONG_NAME},
-		{0, 0, 0, 0}
-	};
+  // The long options recognized by the program
+  struct option long_options[] = {
+    {"status-interval", required_argument, 0, 'i'},
+    {"state-interval", required_argument, 0, 'I'},
+    {"steps", required_argument, 0, 'n'},
+    {"serial", no_argument, 0, 's'},
+    {"parallel", no_argument, 0, 'p'},
+    {"help", no_argument, 0, 'h'},
+    {"version", no_argument, 0, 'V'},
+    {"verbose", no_argument, 0, 'k'},
+    {"neighbor", required_argument, 0, 'l'},
+    {"name", required_argument, 0, LONG_NAME},
+    {"strategy", required_argument, 0, 'S'},
+    {0, 0, 0, 0}
+  };
 
-	// Iterate over all command-line arguments and match any option entries.
-	while ((getopt_ret = getopt_long(argc, argv, short_options, long_options, &long_index)) != -1) {
- 		// Switch the returned option value
-		switch (getopt_ret) {
-			case 0:		// long options
-				if (long_options[long_index].flag != 0)
-					break;
-				// handle other long options without return values
-				break;
-			case 'V':
-				printVersionInformation();
-				return false;
-			case LONG_NAME:
-				if (!fromString<string>(optarg, params->simulationName)) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --name: Invalid simulation name" << std::endl;
-					return false;
-				}
-				break;
-			case 'i':	// status interval
-				params->statusFlag = true;
-				if (!fromString<int>(optarg, params->statusInterval)) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --status_interval (-i): Invalid status interval" << std::endl;
-					return false;
-				}
-				if (params->statusInterval < 0) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --status_interval (-i): Status Interval must be non-negative" << std::endl;
-					return false;
-				}
-				break;
-			case 'I':	// state interval
-				params->stateFlag = true;
-				if (!fromString<int>(optarg, params->stateInterval)) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --state_interval (-I): Invalid state interval" << std::endl;
-					return false;
-				}
-				break;
-			case 'n':	// simulation steps
-				params->stepFlag = true;
-				if (!fromString<int>(optarg, params->stepCount)) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --steps (-n): Invalid step count" << std::endl;
-					return false;
-				}
-				if (params->stepCount <= 0){
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --steps (-n): Step count must be greater than zero" << std::endl;
-					return false;
-				}
-				break;
-			case 's':	// run serial
-				params->serialFlag = true;
-				break;
-			case 'p':	// run parallel
-				params->parallelFlag = true;
-				break;
-			case 'k': // Verbose output
-				params->verboseOutputFlag = true;
-				break;
-			case 'l': 	// use neighbor list
-				params->neighborListFlag = true;
-				if (!fromString<int>(optarg, params->neighborListInterval)) {
-					params->neighborListInterval = DEFAULT_NEIGHBORLIST_INTERVAL;
-				}
-				if (params->neighborListInterval < 1) {
-					std::cerr << APP_NAME << ": ";
-					std::cerr << " --neighborlist_interval (-l): Neighborlist Interval must be greater than 0" << std::endl;
-					return false;
-				}
-				break;
-			case 'h':	// print help
-				printHelpScreen();
-				return false;
-			case ':':	// missing argument
-				if (optopt == 'l') {
-					params->neighborListFlag = true;
-					params->neighborListInterval = DEFAULT_NEIGHBORLIST_INTERVAL;
-				}	else if (sizeof(argv[optind-1]) > 2 && argv[optind-1][0] == '-' && argv[optind-1][1] == '-') {
-					std::cerr << APP_NAME << ": A required argument is missing for ";
-					std::cerr << argv[optind-1] << std::endl;
-					return false;
-				} else {
-					std::cerr << APP_NAME << ": A required argument is missing for ";
-					std::cerr << "-" << (char) optopt << std::endl;
-					return false;
-				}
-				break;
-			case '?':	// unknown option
-				if (optopt) {
-					std::cerr << APP_NAME << ": Unknown option -" << (char) optopt << std::endl;
-				} else if ((optind - 1) < argc) {
-					std::cerr << APP_NAME << ": Unknown option " << argv[optind-1] << std::endl;
-				} else {
-					std::cerr << APP_NAME << ": Unknown option not recognized" << std::endl;
-				}
-				return false;
-			default:	// unknown error
-				std::cerr << APP_NAME << ": Fatal error occurred while parsing command-line" << std::endl;
-				return false;
-		}
-	}
-	// Get the count and list of non-option arguments specified by the user.
-	params->argCount = argc - optind;
-	params->argList = &(argv[optind]);
+  // Iterate over all command-line arguments and match any option entries.
+  while ((getopt_ret = getopt_long(argc, argv, short_options, long_options, &long_index)) != -1) {
+    // Switch the returned option value
+    switch (getopt_ret) {
+      case 0:   // long options
+        if (long_options[long_index].flag != 0)
+          break;
+        // handle other long options without return values
+        break;
+      case 'V':
+        printVersionInformation();
+        return false;
+      case LONG_NAME:
+        if (!fromString<string>(optarg, params->simulationName)) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --name: Invalid simulation name" << std::endl;
+          return false;
+        }
+        break;
+      case 'i': // status interval
+        params->statusFlag = true;
+        if (!fromString<int>(optarg, params->statusInterval)) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --status_interval (-i): Invalid status interval"
+                    << std::endl;
+          return false;
+        }
+        if (params->statusInterval < 0) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --status_interval (-i): Status Interval must be "
+                       "non-negative"
+                    << std::endl;
+          return false;
+        }
+        break;
+      case 'I': // state interval
+        params->stateFlag = true;
+        if (!fromString<int>(optarg, params->stateInterval)) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --state_interval (-I): Invalid state interval"
+                    << std::endl;
+          return false;
+        }
+        break;
+      case 'n': // simulation steps
+        params->stepFlag = true;
+        if (!fromString<int>(optarg, params->stepCount)) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --steps (-n): Invalid step count" << std::endl;
+          return false;
+        }
+        if (params->stepCount <= 0){
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --steps (-n): Step count must be greater than zero"
+                    << std::endl;
+          return false;
+        }
+        break;
+      case 's': // run serial
+        params->serialFlag = true;
+        break;
+      case 'p': // run parallel
+        params->parallelFlag = true;
+        break;
+      case 'k': // Verbose output
+        params->verboseOutputFlag = true;
+        break;
+      case 'l':   // use neighbor list
+        params->neighborListFlag = true;
+        if (!fromString<int>(optarg, params->neighborListInterval)) {
+          params->neighborListInterval = DEFAULT_NEIGHBORLIST_INTERVAL;
+        }
+        if (params->neighborListInterval < 1) {
+          std::cerr << APP_NAME << ": ";
+          std::cerr << " --neighborlist_interval (-l): Neighborlist Interval "
+                       "must be greater than 0"
+                    << std::endl;
+          return false;
+        }
+        break;
+      case 'h': // print help
+        printHelpScreen();
+        return false;
+      case ':': // missing argument
+        if (optopt == 'l') {
+          params->neighborListFlag = true;
+          params->neighborListInterval = DEFAULT_NEIGHBORLIST_INTERVAL;
+        } else if (sizeof(argv[optind-1]) > 2 && argv[optind-1][0] == '-' && argv[optind-1][1] == '-') {
+          std::cerr << APP_NAME << ": A required argument is missing for ";
+          std::cerr << argv[optind-1] << std::endl;
+          return false;
+        } else {
+          std::cerr << APP_NAME << ": A required argument is missing for ";
+          std::cerr << "-" << (char) optopt << std::endl;
+          return false;
+        }
+        break;
+      case 'S':
+        params->simStrategy = string(optarg);
+        break;
+      case '?': // unknown option
+        if (optopt) {
+          std::cerr << APP_NAME << ": Unknown option -"
+                    << (char) optopt << std::endl;
+        } else if ((optind - 1) < argc) {
+          std::cerr << APP_NAME << ": Unknown option " << argv[optind-1]
+                    << std::endl;
+        } else {
+          std::cerr << APP_NAME << ": Unknown option not recognized"
+                    << std::endl;
+        }
+        return false;
+      default:  // unknown error
+        std::cerr << APP_NAME << ": Fatal error occurred while parsing command-line" << std::endl;
+        return false;
+    }
+  }
+  // Get the count and list of non-option arguments specified by the user.
+  params->argCount = argc - optind;
+  params->argList = &(argv[optind]);
 
-	return true;
+  return true;
 }
 
 bool parseCommandLine(CommandParameters* params, SimulationArgs* args) {
-	if (params->argCount < 1) {
-		std::cerr << APP_NAME << ": Input file not specified" << std::endl;
-		return false;
-	} else if (params->argCount > 1) {
-		std::cerr << APP_NAME << ": Too many input files specified" << std::endl;
-		return false;
-	} else if (params->argList == NULL) {
-		std::cerr << APP_NAME << ": Must specify a valid file path" << std::endl;
-		return false;
-	} else if (params->serialFlag && params->parallelFlag) { // conflicting flags
-		std::cerr << APP_NAME << ": Cannot specify both GPU and CPU modes" << std::endl;
-		return false;
-	}
+  if (params->argCount < 1) {
+    std::cerr << APP_NAME << ": Input file not specified" << std::endl;
+    return false;
+  } else if (params->argCount > 1) {
+    std::cerr << APP_NAME << ": Too many input files specified" << std::endl;
+    return false;
+  } else if (params->argList == NULL) {
+    std::cerr << APP_NAME << ": Must specify a valid file path" << std::endl;
+    return false;
+  } else if (params->serialFlag && params->parallelFlag) { // conflicting flags
+    std::cerr << APP_NAME << ": Cannot specify both GPU and CPU modes" << std::endl;
+    return false;
+  }
 
-	// Assign the relevant information that will be used in the simulation
-	// to the command arguments container.
-	if (params->parallelFlag) {	// parallel flag set
-		args->simulationMode = SimulationMode::Parallel;
-	} else if (params->serialFlag) { // serial flag set
-		args->simulationMode = SimulationMode::Serial;
-	} else {
-		args->simulationMode = SimulationMode::Default;
-	}
+  // Assign the relevant information that will be used in the simulation
+  // to the command arguments container.
+  if (params->parallelFlag) { // parallel flag set
+    args->simulationMode = SimulationMode::Parallel;
+  } else if (params->serialFlag) { // serial flag set
+    args->simulationMode = SimulationMode::Serial;
+  } else {
+    args->simulationMode = SimulationMode::Default;
+  }
 
-	if (!parseInputFile(params->argList[0], args->filePath, args->fileType)) {
-		std::cerr << APP_NAME << ": Must specify a config or state file" << std::endl;
-		return false;
-	}
+  // Assign the simulation strategy type
+  if (!params->simStrategy.empty()) {
+    args->strategy = Strategy::getStrategy(params->simStrategy);
+    if (args->strategy == Strategy::Unknown) {
+      std::cerr << APP_NAME << ": Unknown energy calculation strategy "
+                << "specified" << std::endl;
+      return false;
+    }
+  } else {
+    args->strategy = Strategy::Default;
+  }
 
-	args->statusInterval = params->statusInterval;
-	args->stateInterval = params->stateInterval;
-	args->stepCount = params->stepCount;
-	args->simulationName = params->simulationName;
-	args->verboseOutput = params->verboseOutputFlag;
-	args->useNeighborList = params->neighborListFlag;
-	args->neighborListInterval = params->neighborListInterval;
+  if (!parseInputFile(params->argList[0], args->filePath, args->fileType)) {
+    std::cerr << APP_NAME << ": Must specify a config or state file"
+              << std::endl;
+    return false;
+  }
 
-	return true;
+  args->statusInterval = params->statusInterval;
+  args->stateInterval = params->stateInterval;
+  args->stepCount = params->stepCount;
+  args->simulationName = params->simulationName;
+  args->verboseOutput = params->verboseOutputFlag;
+  args->useNeighborList = params->neighborListFlag;
+  args->neighborListInterval = params->neighborListInterval;
+
+  return true;
 }
 
 bool parseInputFile(char* filename, string& name, InputFileType& type) {
-	if (!filename) {
-		return false;
-	} else if (!fromString<string>(filename, name)) {
-		return false;
-	} else if (name.empty()) {
-		std::cerr << APP_NAME << ": Input file must be a valid path" << std::endl;
-		return false;
-	}
+  if (!filename) {
+    return false;
+  } else if (!fromString<string>(filename, name)) {
+    return false;
+  } else if (name.empty()) {
+    std::cerr << APP_NAME << ": Input file must be a valid path" << std::endl;
+    return false;
+  }
 
-	std::string extension = getExtension(name);
-	if (extension == "config") {
-		type = InputFile::Configuration;
-		return true;
-	} else if (extension == "state") {
-		type = InputFile::State;
-		return true;
-	}
+  std::string extension = getExtension(name);
+  if (extension == "config") {
+    type = InputFile::Configuration;
+    return true;
+  } else if (extension == "state") {
+    type = InputFile::State;
+    return true;
+  }
 
-	type = InputFile::Unknown;
-	return false;
+  type = InputFile::Unknown;
+  return false;
 }
 
 void printHelpScreen() {
-	using std::endl;
-	using std::cout;
+  using std::endl;
+  using std::cout;
 
-	cout << endl;
-	cout << "Usage: " << APP_NAME << " <inputfile> [options]" << endl << endl;
+  cout << endl;
+  cout << "Usage: " << APP_NAME << " <inputfile> [options]" << endl << endl;
 
-	cout << "Input File Types\n"
-		  		"=================\n"
-					"The file extension of the input file will determine what phase of the\n"
-		  		"simulation to execute:\n"
-					"\t.config\t: Create a fresh simulation using the given set of\n"
-		  		"\t\t  configuration settings and parameters.\n"
-					"\t.state\t: Resume a previous simulation that was saved.\n\n";
+  cout << "Input File Types\n"
+          "=================\n"
+          "The file extension of the input file will determine what phase of the\n"
+          "simulation to execute:\n"
+          "\t.config\t: Create a fresh simulation using the given set of\n"
+          "\t\t  configuration settings and parameters.\n"
+          "\t.state\t: Resume a previous simulation that was saved.\n\n";
 
-	cout << "Operation Flags\n"
-		  		"====================\n"
-					"This tool can execute a given simulation on both the CPU and the GPU.\n\n";
+  cout << "Operation Flags\n"
+          "====================\n"
+          "This tool can execute a given simulation on both the CPU and the GPU.\n\n";
 
-	cout << "--parallel\t(-p)\n"
-	 				"\tRun the simulation in parallel by executing steps on a CUDA\n"
-		  		"\tcapable device. The program will terminate if no available devices\n"
-		  		"\tare found or if the tool's minimum specifications are not met.\n"
-		  		"\tIf you specify this flag you cannot also specify the --serial\n"
-		  		"\tflag.\n\n";
+  cout << "--parallel\t(-p)\n"
+          "\tRun the simulation in parallel by executing steps on a CUDA\n"
+          "\tcapable device. The program will terminate if no available devices\n"
+          "\tare found or if the tool's minimum specifications are not met.\n"
+          "\tIf you specify this flag you cannot also specify the --serial\n"
+          "\tflag.\n\n";
 
-	cout << "--serial\t(-s)\n"
-	        "\tRun the simulation in serial on the host CPU. If you specify this\n"
-		  		"\tflag you cannot also specify the --parallel flag.\n\n";
+  cout << "--serial\t(-s)\n"
+          "\tRun the simulation in serial on the host CPU. If you specify this\n"
+          "\tflag you cannot also specify the --parallel flag.\n\n";
 
-	cout << "--verbose\t(-k)\n"
-		      "\tRun the simulation printing regular step updates to std::cout.\n\n";
+  cout << "--verbose\t(-k)\n"
+          "\tRun the simulation printing regular step updates to std::cout.\n\n";
 
-	cout << "Simulation Run Parameters\n"
-		  		"==========================\n"
-					"These options define simulation settings and parameters that specify\n"
-	     		"how to the run will execute.\n\n";
+  cout << "Simulation Run Parameters\n"
+          "==========================\n"
+          "These options define simulation settings and parameters that specify\n"
+          "how to the run will execute.\n\n";
 
-	cout << "--name <title>\n"
-					"\tSpecifies the name of the simulation that will be run. This name\n"
-					"\twill be used as the basename for saved state files, as well as\n"
-					"\tthe title of the simulation results.\n\n";
+  cout << "--name <title>\n"
+          "\tSpecifies the name of the simulation that will be run. This name\n"
+          "\twill be used as the basename for saved state files, as well as\n"
+          "\tthe title of the simulation results.\n\n";
 
-	cout << "--steps <count>\t\t(-n)\n"
-					"\tSpecifies how many simulation steps to execute in the Monte\n"
-					"\tCarlo Metropolis algorithm. This value must a valid integer\n"
-					"\tthat is greater than zero.\n\n";
+  cout << "--steps <count>\t\t(-n)\n"
+          "\tSpecifies how many simulation steps to execute in the Monte\n"
+          "\tCarlo Metropolis algorithm. This value must a valid integer\n"
+          "\tthat is greater than zero.\n\n";
 
-	cout << "--neighbor <interval>\t\t(-l)\n"
-					"\tSpecifies using the linked-cell neighborlist structure for molecule\n"
-					"\torganization. The neighborlist is generally faster for large\n"
-					"\tsimulations. Interval dicatates how many steps are executed\n"
-					"\tinbetween updating the neighborlist structure. Having the\n"
-					"\tneighborlist update more often will result in a more accurate\n"
-					"\tsimulation but some performance will be lost. The default is set\n"
-					"\tat 100 and the given interval must be greater than 0.\n\n";
+  cout << "--neighbor <interval>\t\t(-l)\n"
+          "\tSpecifies using the linked-cell neighborlist structure for molecule\n"
+          "\torganization. The neighborlist is generally faster for large\n"
+          "\tsimulations. Interval dicatates how many steps are executed\n"
+          "\tinbetween updating the neighborlist structure. Having the\n"
+          "\tneighborlist update more often will result in a more accurate\n"
+          "\tsimulation but some performance will be lost. The default is set\n"
+          "\tat 100 and the given interval must be greater than 0.\n\n";
 
-	cout << "--status-interval <interval>\t(-i)\n"
-					"\tSpecifies the number of simulation steps between status updates.\n"
-					"\tThese status updates will periodically be printed out that list\n"
-					"\tthe current step number and the current total system energy.\n"
-					"\tThis interval must be a valid non-negative integer value. An\n"
-					"\tinterval of 0 (zero) means that status updates should only\n"
-					"\tprint out at the beginning and the end of the simulation.\n\n";
+  cout << "--status-interval <interval>\t(-i)\n"
+          "\tSpecifies the number of simulation steps between status updates.\n"
+          "\tThese status updates will periodically be printed out that list\n"
+          "\tthe current step number and the current total system energy.\n"
+          "\tThis interval must be a valid non-negative integer value. An\n"
+          "\tinterval of 0 (zero) means that status updates should only\n"
+          "\tprint out at the beginning and the end of the simulation.\n\n";
 
-	cout << "--state-interval <interval>\t(-I)\n"
-					"\tSpecifies the number of simulation steps between state file\n"
-	  			"\tsnapshots of the current simulation run. The program will\n"
-	  			"\tperiodically save the simulation to a state file (*.state)\n"
-		  		"\tthat can be resumed later by the user. This provides checkpoints\n"
-					"\tjust in case a long running simulation is interrupted.\n\n"
-					"\tSpecifying a state interval of zero, or not specifying the\n"
-					"\toption at all, means that only a final state file should be\n"
-					"\twritten at the end of the simulation run. An interval greater\n"
-					"\tthan zero means that multiple state files should be written\n"
-					"\tat the specified intervals. Finally, a state interval less than\n"
-					"\tzero means that no state files should be written at all.\n\n"
-					"\tThe filename for the saved state files will be the simulation\n"
-					"\tname with the current step number appended at the end:\n\n"
-					"\t\t<simulation-name>_<step-num>.state\n\n";
+  cout << "--state-interval <interval>\t(-I)\n"
+          "\tSpecifies the number of simulation steps between state file\n"
+          "\tsnapshots of the current simulation run. The program will\n"
+          "\tperiodically save the simulation to a state file (*.state)\n"
+          "\tthat can be resumed later by the user. This provides checkpoints\n"
+          "\tjust in case a long running simulation is interrupted.\n\n"
+          "\tSpecifying a state interval of zero, or not specifying the\n"
+          "\toption at all, means that only a final state file should be\n"
+          "\twritten at the end of the simulation run. An interval greater\n"
+          "\tthan zero means that multiple state files should be written\n"
+          "\tat the specified intervals. Finally, a state interval less than\n"
+          "\tzero means that no state files should be written at all.\n\n"
+          "\tThe filename for the saved state files will be the simulation\n"
+          "\tname with the current step number appended at the end:\n\n"
+          "\t\t<simulation-name>_<step-num>.state\n\n";
 
-	cout << "Generic Tool Options\n"
-	 		  	"=====================\n\n";
+  cout << "Generic Tool Options\n"
+          "=====================\n\n";
 
-	cout << "--help\t\t(-h)\n"
-					"\tPrint this help information to the standard output stream.\n\n";
+  cout << "--help\t\t(-h)\n"
+          "\tPrint this help information to the standard output stream.\n\n";
 
-	cout << "--version\t(-V)\n"
-					"\tPrint version information of this tool to the standard output\n"
-			  	"\tstream.\n\n";
+  cout << "--version\t(-V)\n"
+          "\tPrint version information of this tool to the standard output\n"
+          "\tstream.\n\n";
 }
 
 void printVersionInformation() {
-	std::cout << APP_NAME << ": MCGPU Monte Carlo Simulator" << std::endl;
+  std::cout << APP_NAME << ": MCGPU Monte Carlo Simulator" << std::endl;
 
-	#ifdef DEBUG
-		std::cout << "Current Build: Debug" << std::endl;
-	#else
-		std::cout << "Current Build: Release" << std::endl;
-	#endif
+  #ifdef DEBUG
+    std::cout << "Current Build: Debug" << std::endl;
+  #else
+    std::cout << "Current Build: Release" << std::endl;
+  #endif
 
-	#ifdef DOUBLE_PRECISION
-		std::cout << "Floating-point Precision: Double" << std::endl;
-	#else
-	  std::cout << "Floating-point Precision: Single" << std::endl;
-	#endif
+  #ifdef DOUBLE_PRECISION
+    std::cout << "Floating-point Precision: Double" << std::endl;
+  #else
+    std::cout << "Floating-point Precision: Single" << std::endl;
+  #endif
 }

--- a/src/Applications/CommandParsing.h
+++ b/src/Applications/CommandParsing.h
@@ -15,196 +15,175 @@
 #include "Metropolis/SimulationArgs.h"
 
 #ifndef APP_NAME
-#define APP_NAME "metrosim"    *< The executable name of the application.
+#define APP_NAME "metrosim"
 #endif
 
 #define DEFAULT_STATUS_INTERVAL 1000
 #define DEFAULT_NEIGHBORLIST_INTERVAL 100
 
-	/**
-	 * Contains the intermediate values and flags read in from the command
-	 * line.
-	 *
-	 * @note This data structure will have to be updated when new commands
-	 * are added.
-	 */
-	struct CommandParameters {
-
-		/**
-		 * The number of simulation steps between status updates.
-		 * @note This interval must be a non-negative number, and specifying
-		 *     an interval of 0 means status updates will occur only
-		 *     at the beginning and end of the simulation.
-		 */
-		int statusInterval;
-
-		/**
-		 * The number of simulation steps between state file saves.
-		 *
-		 * @note This interval must be a non-negative number, and specifying
-		 *    an interval of 0 means a single state file should be saved
-		 *    at the very end of the simulation (which is the default
-		 *    behavior with no interval specified).
-		 */
-		int stateInterval;
-
-		/**
-		 * The number of simulation steps to execute in the current run.
-		 * This must be a valid integer number greater than zero.
-		 */
-		int stepCount;
-
-		/**
-		 * Declares whether the help option was specified.
-		 */
-		bool helpFlag;
-
-		/**
-		 * Declares whether the version option was specified.
-		 */
-		bool versionFlag;
-
-    /**
-		 * The number of non-option arguments given by the user.
-		 */
-		int argCount;
-
-    /**
-		 * The list of non-option arguments given by the user.
-     */
-		char** argList;
-
-    /**
-		 * The optional name of the simulation run.
-     */
-		std::string simulationName;
-
-		/**
-		 * Declares whether the status interval option was specified.
-		 */
-		bool statusFlag;
-
-    /**
-		 * Declare whether the state interval option was specified
-     */
-		bool stateFlag;
-
-		/**
-		 * Declares whether the steps option was specified.
-     */
-		bool stepFlag;
-
-    /**
-		 * Declares whether the serial execution option was specified.
-     */
-		bool serialFlag;
-
-    /**
-		 * Declares whether the parallel execution option was specified.
-     */
-		bool parallelFlag;
-
-    /**
-		 * Declares whether or not to display the printed run
-		 * information to standard cout.
-     */
-		bool verboseOutputFlag;
-
-    /**
-		 * Declares whether the use of the Neighbor-list is enabled.
-     */
-		bool neighborListFlag;
-
-    /**
-		 * The number of simulation steps between updating the neighborlist.
-		 * @note This interval must be a non-negative number, and specifying
-		 *     an interval of 0 means the initial neighborlist will not be updated
-     */
-		int neighborListInterval;
-
-		/**
-		 * Default constructor
-     */
-		CommandParameters() :	statusInterval(DEFAULT_STATUS_INTERVAL),
-								stateInterval(0),
-								stepCount(0),
-								argCount(0),
-								argList(NULL),
-								helpFlag(false),
-								versionFlag(false),
-								statusFlag(false),
-								stepFlag(false),
-								serialFlag(false),
-								parallelFlag(false),
-								verboseOutputFlag(false),
-								neighborListFlag(false),
-								neighborListInterval(DEFAULT_NEIGHBORLIST_INTERVAL)		{}
-	};
+/**
+ * Contains the intermediate values and flags read in from the command
+ * line.
+ *
+ * @note This data structure will have to be updated when new commands
+ * are added.
+ */
+struct CommandParameters {
 
   /**
-	 * Goes through each argument specified from the command line and checks
-	 * for usage errors, then fills a list of simulation settings and values
-	 * that will be used by the application.
-	 *
-	 * @param[in] argc The number of entries in the arguments list.
-	 * @param[in] argv The list of command line arguments given to the program.
-	 * @param[out] args The list of settings that define the behavior and
-	 *     values for the simulation to use.
-	 * @returns True if the simulation should be executed; false if the
-	 *     simulation should not be executed.
-	 */
-	bool getCommands(int argc, char** argv, SimulationArgs* args);
-
-  /**
-	 * Analyzes the syntax of the command line arguments and fills a parameter
-	 * list with flags and raw values.
-	 *
-	 * @param[in] argc The number of entries in the arguments list.
-	 * @param[in] argv The list of command line arguments given to the program.
-	 * @param[out] params The list of command line parameters that contain
-	 *     intermediate values ready to be parsed.
-	 * @returns True if no errors occurred; false if a syntax error occurred.
+   * The number of simulation steps between status updates.
+   * @note This interval must be a non-negative number, and specifying
+   *     an interval of 0 means status updates will occur only
+   *     at the beginning and end of the simulation.
    */
-	bool readCommandLine(int argc, char** argv, CommandParameters* params);
-
-	/**
-	 * Analyzes the semantics of the command line parameters and fills the
-	 * simulation arguments list with settings and values.
-	 *
-	 * @param[in] params The list of command line parameters that contain
-	 *     intermediate values ready to be parsed.
-	 * @param[out] args The list of settings that define the behavior and
-	 *     values for the simulation to use.
-	 * @returns True if no errors occurred and the simulation shoud execute;
-	 *     false if a semantics error occurred or the simulation was halted.
-	 * @remarks Currently if the user specifies the --help or -h options via
-	 *     the command line input to the program, the simulation will not
-	 *     execute, and instead usage information will be printed to the user
-	 *     and the program will terminate. This complies with GNU conventions.
-	 */
-	bool parseCommandLine(CommandParameters* params, SimulationArgs* args);
-
-	/**
-	 * Analyzes a file name and determines its type.
-	 *
-	 * @param[in] filename The name of the file, as specified at the command line.
-	 * @param[out] name The filename, converted to std::string, if applicable.
-	 * @param[out] type The type of the file, either InputFile::Configuration,
-	 * 		 InputFile::State, or InputFile::Unknown
-	 * @returns True if the filename is valid, false otherwise.
-	 */
-	bool parseInputFile(char* filename, std::string& name, InputFileType& type);
+  int statusInterval;
 
   /**
-	 * Outputs the help documentation to the standard output stream and
-	 * displays how to use the application.
+   * The number of simulation steps between state file saves.
+   *
+   * @note This interval must be a non-negative number, and specifying
+   *    an interval of 0 means a single state file should be saved
+   *    at the very end of the simulation (which is the default
+   *    behavior with no interval specified).
    */
-	void printHelpScreen();
+  int stateInterval;
 
   /**
-	 * Outputs the current program version and build information to the
-	 * standard output stream.
-	 */
-	void printVersionInformation();
+   * The number of simulation steps to execute in the current run.
+   * This must be a valid integer number greater than zero.
+   */
+  int stepCount;
+
+  /** Declares whether the help option was specified. */
+  bool helpFlag;
+
+  /** Declares whether the version option was specified. */
+  bool versionFlag;
+
+  /** The number of non-option arguments given by the user. */
+  int argCount;
+
+  /** The list of non-option arguments given by the user. */
+  char** argList;
+
+  /** The optional name of the simulation run. */
+  std::string simulationName;
+
+  /** Declares whether the status interval option was specified. */
+  bool statusFlag;
+
+  /** Declare whether the state interval option was specified */
+  bool stateFlag;
+
+  /** Declares whether the steps option was specified.  */
+  bool stepFlag;
+
+  /** Declares whether the serial execution option was specified. */
+  bool serialFlag;
+
+  /** Declares whether the parallel execution option was specified. */
+  bool parallelFlag;
+
+  /**
+   * Declares whether or not to display the printed run
+   * information to standard cout.
+   */
+  bool verboseOutputFlag;
+
+  /** Declares whether the use of the Neighbor-list is enabled. */
+  bool neighborListFlag;
+
+  /**
+   * The number of simulation steps between updating the neighborlist.
+   * @note This interval must be a non-negative number, and specifying
+   *     an interval of 0 means the initial neighborlist will not be updated
+   */
+  int neighborListInterval;
+
+  /** The simulation strategy specified by the user */
+  std::string simStrategy;
+
+  /** Default constructor */
+  CommandParameters() : statusInterval(DEFAULT_STATUS_INTERVAL),
+              stateInterval(0),
+              stepCount(0),
+              argCount(0),
+              argList(NULL),
+              helpFlag(false),
+              versionFlag(false),
+              statusFlag(false),
+              stepFlag(false),
+              serialFlag(false),
+              parallelFlag(false),
+              verboseOutputFlag(false),
+              neighborListFlag(false),
+              neighborListInterval(DEFAULT_NEIGHBORLIST_INTERVAL)   {}
+};
+
+/**
+ * Goes through each argument specified from the command line and checks
+ * for usage errors, then fills a list of simulation settings and values
+ * that will be used by the application.
+ *
+ * @param[in] argc The number of entries in the arguments list.
+ * @param[in] argv The list of command line arguments given to the program.
+ * @param[out] args The list of settings that define the behavior and
+ *     values for the simulation to use.
+ * @returns True if the simulation should be executed; false if the
+ *     simulation should not be executed.
+ */
+bool getCommands(int argc, char** argv, SimulationArgs* args);
+
+/**
+ * Analyzes the syntax of the command line arguments and fills a parameter
+ * list with flags and raw values.
+ *
+ * @param[in] argc The number of entries in the arguments list.
+ * @param[in] argv The list of command line arguments given to the program.
+ * @param[out] params The list of command line parameters that contain
+ *     intermediate values ready to be parsed.
+ * @returns True if no errors occurred; false if a syntax error occurred.
+ */
+bool readCommandLine(int argc, char** argv, CommandParameters* params);
+
+/**
+ * Analyzes the semantics of the command line parameters and fills the
+ * simulation arguments list with settings and values.
+ *
+ * @param[in] params The list of command line parameters that contain
+ *     intermediate values ready to be parsed.
+ * @param[out] args The list of settings that define the behavior and
+ *     values for the simulation to use.
+ * @returns True if no errors occurred and the simulation shoud execute;
+ *     false if a semantics error occurred or the simulation was halted.
+ * @remarks Currently if the user specifies the --help or -h options via
+ *     the command line input to the program, the simulation will not
+ *     execute, and instead usage information will be printed to the user
+ *     and the program will terminate. This complies with GNU conventions.
+ */
+bool parseCommandLine(CommandParameters* params, SimulationArgs* args);
+
+/**
+ * Analyzes a file name and determines its type.
+ *
+ * @param[in] filename The name of the file, as specified at the command line.
+ * @param[out] name The filename, converted to std::string, if applicable.
+ * @param[out] type The type of the file, either InputFile::Configuration,
+ *     InputFile::State, or InputFile::Unknown
+ * @returns True if the filename is valid, false otherwise.
+ */
+bool parseInputFile(char* filename, std::string& name, InputFileType& type);
+
+/**
+ * Outputs the help documentation to the standard output stream and
+ * displays how to use the application.
+ */
+void printHelpScreen();
+
+/**
+ * Outputs the current program version and build information to the
+ * standard output stream.
+ */
+void printVersionInformation();
 
 #endif

--- a/src/Metropolis/BruteForceStep.cpp
+++ b/src/Metropolis/BruteForceStep.cpp
@@ -34,7 +34,7 @@ Real BruteForceCalcs::calcMolecularEnergyContribution(int currMol,
     if (otherMol != currMol) {
       int p2Start = molData[MOL_PIDX_START][otherMol];
       int p2End = molData[MOL_PIDX_COUNT][otherMol] + p2Start;
-      if (moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
+      if (SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
                            pIdxes, cutoff)) {
         total += calcMoleculeInteractionEnergy(currMol, otherMol, molData,
                                                aData, atomCoords, bSize);
@@ -43,43 +43,6 @@ Real BruteForceCalcs::calcMolecularEnergyContribution(int currMol,
   }
 
   return total;
-}
-
-bool BruteForceCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
-                                       int p2End, Real** atomCoords,
-                                       Real* bSize, int* primaryIndexes,
-                                       Real cutoff) {
-  bool out = false;
-  for (int p1Idx = p1Start; p1Idx < p1End; p1Idx++) {
-    int p1 = primaryIndexes[p1Idx];
-    for (int p2Idx = p2Start; p2Idx < p2End; p2Idx++) {
-      int p2 = primaryIndexes[p2Idx];
-      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <= cutoff * cutoff);
-    }
-  }
-  return out;
-}
-
-Real BruteForceCalcs::calcAtomDistSquared(int a1, int a2, Real** aCoords,
-                                          Real* bSize) {
-  Real dx = makePeriodic(aCoords[X_COORD][a2] - aCoords[X_COORD][a1],
-                         X_COORD, bSize);
-  Real dy = makePeriodic(aCoords[Y_COORD][a2] - aCoords[Y_COORD][a1],
-                         Y_COORD, bSize);
-  Real dz = makePeriodic(aCoords[Z_COORD][a2] - aCoords[Z_COORD][a1],
-                         Z_COORD, bSize);
-
-  return dx * dx + dy * dy + dz * dz;
-}
-
-Real BruteForceCalcs::makePeriodic(Real x, int dimension, Real* bSize) {
-  Real dimLength = bSize[dimension];
-
-  int lt = (x < -0.5 * dimLength); // 1 or 0
-  x += lt * dimLength;
-  int gt = (x > 0.5 * dimLength);  // 1 or 0
-  x -= gt * dimLength;
-  return x;
 }
 
 Real BruteForceCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
@@ -101,12 +64,12 @@ Real BruteForceCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
       if (aData[ATOM_SIGMA][i] >= 0 && aData[ATOM_SIGMA][j] >= 0
           && aData[ATOM_EPSILON][i] >= 0 && aData[ATOM_EPSILON][j] >= 0) {
 
-        const Real r2 = calcAtomDistSquared(i, j, aCoords, bSize);
+        const Real r2 = SimCalcs::calcAtomDistSquared(i, j, aCoords, bSize);
         if (r2 == 0.0) {
           energySum += 0.0;
         } else {
-          energySum += calcLJEnergy(i, j, r2, aData);
-          energySum += calcChargeEnergy(i, j, sqrt(r2), aData);
+          energySum += SimCalcs::calcLJEnergy(i, j, r2, aData);
+          energySum += SimCalcs::calcChargeEnergy(i, j, sqrt(r2), aData);
         }
       }
     }
@@ -114,37 +77,3 @@ Real BruteForceCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
 
   return (energySum);
 }
-
-Real BruteForceCalcs::calcLJEnergy(int a1, int a2, Real r2, Real** aData) {
-  if (r2 == 0.0) {
-    return 0.0;
-  } else {
-    const Real sigma = calcBlending(aData[ATOM_SIGMA][a1],
-        aData[ATOM_SIGMA][a2]);
-    const Real epsilon = calcBlending(aData[ATOM_EPSILON][a1],
-        aData[ATOM_EPSILON][a2]);
-
-    const Real s2r2 = pow(sigma, 2) / r2;
-    const Real s6r6 = pow(s2r2, 3);
-    const Real s12r12 = pow(s6r6, 2);
-    return 4.0 * epsilon * (s12r12 - s6r6);
-  }
-}
-
-Real BruteForceCalcs::calcChargeEnergy(int a1, int a2, Real r, Real** aData) {
-  if (r == 0.0) {
-    return 0.0;
-  } else {
-    const Real e = 332.06;
-    return (aData[ATOM_CHARGE][a1] * aData[ATOM_CHARGE][a2] * e) / r;
-  }
-}
-
-Real BruteForceCalcs::calcBlending (Real a, Real b) {
-  if (a * b >= 0) {
-    return sqrt(a*b);
-  } else {
-    return sqrt(-1*a*b);
-  }
-}
-

--- a/src/Metropolis/BruteForceStep.cpp
+++ b/src/Metropolis/BruteForceStep.cpp
@@ -34,8 +34,8 @@ Real BruteForceCalcs::calcMolecularEnergyContribution(int currMol,
     if (otherMol != currMol) {
       int p2Start = molData[MOL_PIDX_START][otherMol];
       int p2End = molData[MOL_PIDX_COUNT][otherMol] + p2Start;
-      if (SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
-                           pIdxes, cutoff)) {
+      if (SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End,
+                                     atomCoords, bSize, pIdxes, cutoff)) {
         total += calcMoleculeInteractionEnergy(currMol, otherMol, molData,
                                                aData, atomCoords, bSize);
       }

--- a/src/Metropolis/BruteForceStep.h
+++ b/src/Metropolis/BruteForceStep.h
@@ -58,80 +58,10 @@ namespace BruteForceCalcs {
    * @param atomCoords The coordinates of the atoms to check.
    * @return true if the molecules are in range, false otherwise.
    */
-  #pragma acc routine seq
-  bool moleculesInRange(int p1Start, int p1End, int p2Start, int p2End,
-                        Real** atomCoords, Real* bSize, int* primaryIndexes,
-                        Real cutoff);
-
-  /**
-   * Calculates the square of the distance between two atoms.
-   *
-   * @param a1 The atom index of the first atom.
-   * @param a2 The atom index of the second atom.
-   * @return The square of the distance between the atoms.
-   */
-  #pragma acc routine seq
-  Real calcAtomDistSquared(int a1, int a2, Real** aCoords,
-                           Real* bSize);
-
-  /**
-   * Given a distance, makes the distance periodic to mitigate distances
-   * greater than half the length of the box.
-   *
-   * @param x The measurement to make periodic.
-   * @param dimension The dimension the measurement must be made periodic in.
-   * @return The measurement, scaled to be periodic.
-   */
-  #pragma acc routine seq
-  Real makePeriodic(Real x, int dimension, Real* bSize);
-
-  /**
-   * Determines whether or not two molecule's primaryIndexes are within the
-   * cutoff range of one another.
-   *
-   * @param p1Start The index of the first primary index from molecule 1.
-   * @param p1End index of the last primary index from molecule 1,  + 1.
-   * @param p2Start index of the first primary index from molecule 2.
-   * @param p2End index of the last primary index from molecule 2,  + 1.
-   * @param atomCoords The coordinates of the atoms to check.
-   * @return true if the molecules are in range, false otherwise.
-   */
   #pragma acc routine vector
   Real calcMoleculeInteractionEnergy (int m1, int m2, int** molData,
                                       Real** aData, Real** aCoords,
                                       Real* bSize);
-
-  /**
-   * Calculates the Lennard - Jones potential between two atoms.
-   *
-   * @param a1  The atom index of the first atom.
-   * @param a2  The atom index of the second atom.
-   * @param r2  The distance between the atoms, squared.
-   * @return The Lennard - Jones potential from the two atoms' interaction.
-   */
-  #pragma acc routine seq
-  Real calcLJEnergy(int a1, int a2, Real r2, Real** aData);
-
-  /**
-   * Calculates the Coloumb potential between two atoms.
-   *
-   * @param a1 The atom index of the first atom.
-   * @param a2 The atom index of the second atom.
-   * @param r  The distance between the atoms.
-   * @return The Coloumb potential from the two atoms' interaction.
-   */
-  #pragma acc routine seq
-  Real calcChargeEnergy(int a1, int a2, Real r, Real** aData);
-
-  /**
-   * Calculates the geometric mean of two real numbers.
-   *
-   * @param a The first real number.
-   * @param b The second real number.
-   * @return sqrt(|a*b|), the geometric mean of the two numbers.
-   */
-  #pragma acc routine seq
-  Real calcBlending (Real a, Real b);
 }
 
 #endif

--- a/src/Metropolis/ProximityMatrixStep.cpp
+++ b/src/Metropolis/ProximityMatrixStep.cpp
@@ -1,0 +1,249 @@
+#include "ProximityMatrixStep.h"
+#include "SimulationStep.h"
+#include "GPUCopy.h"
+#include <openacc.h>
+
+
+ProximityMatrixStep::~ProximityMatrixStep() {
+  ProximityMatrixCalcs::freeProximityMatrix(this->proximityMatrix);
+  this->proximityMatrix = NULL;
+}
+
+Real ProximityMatrixStep::calcMolecularEnergyContribution(int currMol,
+                                                     int startMol) {
+  return ProximityMatrixCalcs::calcMolecularEnergyContribution(currMol, startMol, this->proximityMatrix);
+}
+
+Real ProximityMatrixStep::calcSystemEnergy(Real &subLJ, Real &subCharge, int numMolecules) {
+  Real result = SimulationStep::calcSystemEnergy(subLJ, subCharge, numMolecules);
+  this->proximityMatrix = ProximityMatrixCalcs::createProximityMatrix();
+  return result;
+}
+
+void ProximityMatrixStep::changeMolecule(int molIdx, SimBox *box) {
+  SimulationStep::changeMolecule(molIdx, box);
+  ProximityMatrixCalcs::updateProximityMatrix(this->proximityMatrix, molIdx);
+}
+
+void ProximityMatrixStep::rollback(int molIdx, SimBox *box) {
+  SimulationStep::rollback(molIdx, box);
+  ProximityMatrixCalcs::updateProximityMatrix(this->proximityMatrix, molIdx);
+}
+
+// ----- ProximityMatrixCalcs Definitions -----
+
+Real ProximityMatrixCalcs::calcMolecularEnergyContribution(int currMol,
+                                                      int startMol, char *proximityMatrix) {
+  Real total = 0;
+
+  int **molData = GPUCopy::moleculeDataPtr();
+  Real **atomCoords = GPUCopy::atomCoordinatesPtr();
+  Real *bSize = GPUCopy::sizePtr();
+  int *pIdxes = GPUCopy::primaryIndexesPtr();
+  Real **aData = GPUCopy::atomDataPtr();
+  Real cutoff = SimCalcs::sb->cutoff;
+  const long numMolecules = SimCalcs::sb->numMolecules;
+
+  const int p1Start = SimCalcs::sb->moleculeData[MOL_PIDX_START][currMol];
+  const int p1End = (SimCalcs::sb->moleculeData[MOL_PIDX_COUNT][currMol]
+                     + p1Start);
+
+  if (proximityMatrix == NULL) {
+    #pragma acc parallel loop gang deviceptr(molData, atomCoords, bSize, \
+        pIdxes, aData) if (SimCalcs::on_gpu) vector_length(64)
+    for (int otherMol = startMol; otherMol < numMolecules; otherMol++) {
+      if (otherMol != currMol) {
+        int p2Start = molData[MOL_PIDX_START][otherMol];
+        int p2End = molData[MOL_PIDX_COUNT][otherMol] + p2Start;
+        if (moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
+                             pIdxes, cutoff)) {
+          total += calcMoleculeInteractionEnergy(currMol, otherMol, molData,
+                                                 aData, atomCoords, bSize);
+        }
+      }
+    }
+  } else {
+    #pragma acc parallel loop gang deviceptr(molData, atomCoords, bSize, \
+        pIdxes, aData, proximityMatrix) if (SimCalcs::on_gpu) vector_length(64)
+    for (int otherMol = startMol; otherMol < numMolecules; otherMol++) {
+      if (otherMol != currMol) {
+        //int p2Start = molData[MOL_PIDX_START][otherMol];
+        //int p2End = molData[MOL_PIDX_COUNT][otherMol] + p2Start;
+        if (proximityMatrix[currMol*numMolecules + otherMol]) {
+          total += calcMoleculeInteractionEnergy(currMol, otherMol, molData,
+                                                 aData, atomCoords, bSize);
+        }
+      }
+    }
+  }
+
+  return total;
+}
+
+// FIXME BEGIN FUNCTIONS DUPLICATED FROM BRUTEFORCESTEP...
+
+bool ProximityMatrixCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
+                                       int p2End, Real** atomCoords,
+                                       Real* bSize, int* primaryIndexes,
+                                       Real cutoff) {
+  bool out = false;
+  for (int p1Idx = p1Start; p1Idx < p1End; p1Idx++) {
+    int p1 = primaryIndexes[p1Idx];
+    for (int p2Idx = p2Start; p2Idx < p2End; p2Idx++) {
+      int p2 = primaryIndexes[p2Idx];
+      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <= cutoff * cutoff);
+    }
+  }
+  return out;
+}
+
+Real ProximityMatrixCalcs::calcAtomDistSquared(int a1, int a2, Real** aCoords,
+                                          Real* bSize) {
+  Real dx = makePeriodic(aCoords[X_COORD][a2] - aCoords[X_COORD][a1],
+                         X_COORD, bSize);
+  Real dy = makePeriodic(aCoords[Y_COORD][a2] - aCoords[Y_COORD][a1],
+                         Y_COORD, bSize);
+  Real dz = makePeriodic(aCoords[Z_COORD][a2] - aCoords[Z_COORD][a1],
+                         Z_COORD, bSize);
+
+  return dx * dx + dy * dy + dz * dz;
+}
+
+Real ProximityMatrixCalcs::makePeriodic(Real x, int dimension, Real* bSize) {
+  Real dimLength = bSize[dimension];
+
+  int lt = (x < -0.5 * dimLength); // 1 or 0
+  x += lt * dimLength;
+  int gt = (x > 0.5 * dimLength);  // 1 or 0
+  x -= gt * dimLength;
+  return x;
+}
+
+Real ProximityMatrixCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
+                                                     int** molData,
+                                                     Real** aData,
+                                                     Real** aCoords,
+                                                     Real* bSize) {
+  Real energySum = 0;
+
+  const int m1Start = molData[MOL_START][m1];
+  const int m1End = molData[MOL_LEN][m1] + m1Start;
+
+  const int m2Start = molData[MOL_START][m2];
+  const int m2End = molData[MOL_LEN][m2] + m2Start;
+
+  #pragma acc loop vector collapse(2) reduction(+:energySum)
+  for (int i = m1Start; i < m1End; i++) {
+    for (int j = m2Start; j < m2End; j++) {
+      if (aData[ATOM_SIGMA][i] >= 0 && aData[ATOM_SIGMA][j] >= 0
+          && aData[ATOM_EPSILON][i] >= 0 && aData[ATOM_EPSILON][j] >= 0) {
+
+        const Real r2 = calcAtomDistSquared(i, j, aCoords, bSize);
+        if (r2 == 0.0) {
+          energySum += 0.0;
+        } else {
+          energySum += calcLJEnergy(i, j, r2, aData);
+          energySum += calcChargeEnergy(i, j, sqrt(r2), aData);
+        }
+      }
+    }
+  }
+
+  return (energySum);
+}
+
+Real ProximityMatrixCalcs::calcLJEnergy(int a1, int a2, Real r2, Real** aData) {
+  if (r2 == 0.0) {
+    return 0.0;
+  } else {
+    const Real sigma = calcBlending(aData[ATOM_SIGMA][a1],
+        aData[ATOM_SIGMA][a2]);
+    const Real epsilon = calcBlending(aData[ATOM_EPSILON][a1],
+        aData[ATOM_EPSILON][a2]);
+
+    const Real s2r2 = pow(sigma, 2) / r2;
+    const Real s6r6 = pow(s2r2, 3);
+    const Real s12r12 = pow(s6r6, 2);
+    return 4.0 * epsilon * (s12r12 - s6r6);
+  }
+}
+
+Real ProximityMatrixCalcs::calcChargeEnergy(int a1, int a2, Real r, Real** aData) {
+  if (r == 0.0) {
+    return 0.0;
+  } else {
+    const Real e = 332.06;
+    return (aData[ATOM_CHARGE][a1] * aData[ATOM_CHARGE][a2] * e) / r;
+  }
+}
+
+Real ProximityMatrixCalcs::calcBlending (Real a, Real b) {
+  if (a * b >= 0) {
+    return sqrt(a*b);
+  } else {
+    return sqrt(-1*a*b);
+  }
+}
+
+// FIXME ...END FUNCTIONS DUPLICATED FROM BRUTEFORCESTEP
+
+char *ProximityMatrixCalcs::createProximityMatrix() {
+  const long numMolecules = SimCalcs::sb->numMolecules;
+  const Real cutoff = SimCalcs::sb->cutoff;
+
+  int** molData = GPUCopy::moleculeDataPtr();
+  Real** atomCoords = GPUCopy::atomCoordinatesPtr();
+  Real* bSize = GPUCopy::sizePtr();
+  int* pIdxes = GPUCopy::primaryIndexesPtr();
+  Real** aData = GPUCopy::atomDataPtr();
+
+  char *matrix;
+  if (SimCalcs::on_gpu) {
+    matrix = (char *)acc_malloc(numMolecules * numMolecules * sizeof(char));
+  } else {
+    matrix = (char *)malloc(numMolecules * numMolecules * sizeof(char));
+  }
+  assert(matrix != NULL);
+#pragma acc parallel loop deviceptr(molData, atomCoords, bSize, pIdxes, aData, matrix) if(SimCalcs::on_gpu)
+  for (int i = 0; i < numMolecules; i++) {
+    const int p1Start = molData[MOL_PIDX_START][i];
+    const int p1End   = molData[MOL_PIDX_COUNT][i] + p1Start;
+#pragma acc loop seq
+    for (int j = 0; j < numMolecules; j++) {
+      const int p2Start = molData[MOL_PIDX_START][j];
+      const int p2End = molData[MOL_PIDX_COUNT][j] + p2Start;
+      matrix[i*numMolecules + j] = (j != i && ProximityMatrixCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
+    }
+  }
+  return matrix;
+}
+
+void ProximityMatrixCalcs::updateProximityMatrix(char *matrix, int i) {
+  const long numMolecules = SimCalcs::sb->numMolecules;
+  const Real cutoff = SimCalcs::sb->cutoff;
+
+  int** molData = GPUCopy::moleculeDataPtr();
+  Real** atomCoords = GPUCopy::atomCoordinatesPtr();
+  Real* bSize = GPUCopy::sizePtr();
+  int* pIdxes = GPUCopy::primaryIndexesPtr();
+  Real** aData = GPUCopy::atomDataPtr();
+
+#pragma acc parallel loop deviceptr(molData, atomCoords, bSize, pIdxes, aData, matrix) if(SimCalcs::on_gpu)
+  for (int j = 0; j < numMolecules; j++) {
+    const int p1Start = molData[MOL_PIDX_START][i];
+    const int p1End   = molData[MOL_PIDX_COUNT][i] + p1Start;
+    const int p2Start = molData[MOL_PIDX_START][j];
+    const int p2End = molData[MOL_PIDX_COUNT][j] + p2Start;
+
+    const char entry = (j != i && ProximityMatrixCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
+    matrix[i*numMolecules + j] = entry;
+    matrix[j*numMolecules + i] = entry;
+  }
+}
+
+void ProximityMatrixCalcs::freeProximityMatrix(char *matrix) {
+  if (SimCalcs::on_gpu)
+    acc_free(matrix);
+  else
+    free(matrix);
+}

--- a/src/Metropolis/ProximityMatrixStep.cpp
+++ b/src/Metropolis/ProximityMatrixStep.cpp
@@ -1,3 +1,4 @@
+#include "BruteForceStep.h"
 #include "ProximityMatrixStep.h"
 #include "SimulationStep.h"
 #include "GPUCopy.h"
@@ -55,7 +56,7 @@ Real ProximityMatrixCalcs::calcMolecularEnergyContribution(int currMol,
       if (otherMol != currMol) {
         int p2Start = molData[MOL_PIDX_START][otherMol];
         int p2End = molData[MOL_PIDX_COUNT][otherMol] + p2Start;
-        if (moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
+        if (SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize,
                              pIdxes, cutoff)) {
           total += calcMoleculeInteractionEnergy(currMol, otherMol, molData,
                                                  aData, atomCoords, bSize);
@@ -82,43 +83,6 @@ Real ProximityMatrixCalcs::calcMolecularEnergyContribution(int currMol,
 
 // FIXME BEGIN FUNCTIONS DUPLICATED FROM BRUTEFORCESTEP...
 
-bool ProximityMatrixCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
-                                       int p2End, Real** atomCoords,
-                                       Real* bSize, int* primaryIndexes,
-                                       Real cutoff) {
-  bool out = false;
-  for (int p1Idx = p1Start; p1Idx < p1End; p1Idx++) {
-    int p1 = primaryIndexes[p1Idx];
-    for (int p2Idx = p2Start; p2Idx < p2End; p2Idx++) {
-      int p2 = primaryIndexes[p2Idx];
-      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <= cutoff * cutoff);
-    }
-  }
-  return out;
-}
-
-Real ProximityMatrixCalcs::calcAtomDistSquared(int a1, int a2, Real** aCoords,
-                                          Real* bSize) {
-  Real dx = makePeriodic(aCoords[X_COORD][a2] - aCoords[X_COORD][a1],
-                         X_COORD, bSize);
-  Real dy = makePeriodic(aCoords[Y_COORD][a2] - aCoords[Y_COORD][a1],
-                         Y_COORD, bSize);
-  Real dz = makePeriodic(aCoords[Z_COORD][a2] - aCoords[Z_COORD][a1],
-                         Z_COORD, bSize);
-
-  return dx * dx + dy * dy + dz * dz;
-}
-
-Real ProximityMatrixCalcs::makePeriodic(Real x, int dimension, Real* bSize) {
-  Real dimLength = bSize[dimension];
-
-  int lt = (x < -0.5 * dimLength); // 1 or 0
-  x += lt * dimLength;
-  int gt = (x > 0.5 * dimLength);  // 1 or 0
-  x -= gt * dimLength;
-  return x;
-}
-
 Real ProximityMatrixCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
                                                      int** molData,
                                                      Real** aData,
@@ -138,51 +102,18 @@ Real ProximityMatrixCalcs::calcMoleculeInteractionEnergy (int m1, int m2,
       if (aData[ATOM_SIGMA][i] >= 0 && aData[ATOM_SIGMA][j] >= 0
           && aData[ATOM_EPSILON][i] >= 0 && aData[ATOM_EPSILON][j] >= 0) {
 
-        const Real r2 = calcAtomDistSquared(i, j, aCoords, bSize);
+        const Real r2 = SimCalcs::calcAtomDistSquared(i, j, aCoords, bSize);
         if (r2 == 0.0) {
           energySum += 0.0;
         } else {
-          energySum += calcLJEnergy(i, j, r2, aData);
-          energySum += calcChargeEnergy(i, j, sqrt(r2), aData);
+          energySum += SimCalcs::calcLJEnergy(i, j, r2, aData);
+          energySum += SimCalcs::calcChargeEnergy(i, j, sqrt(r2), aData);
         }
       }
     }
   }
 
   return (energySum);
-}
-
-Real ProximityMatrixCalcs::calcLJEnergy(int a1, int a2, Real r2, Real** aData) {
-  if (r2 == 0.0) {
-    return 0.0;
-  } else {
-    const Real sigma = calcBlending(aData[ATOM_SIGMA][a1],
-        aData[ATOM_SIGMA][a2]);
-    const Real epsilon = calcBlending(aData[ATOM_EPSILON][a1],
-        aData[ATOM_EPSILON][a2]);
-
-    const Real s2r2 = pow(sigma, 2) / r2;
-    const Real s6r6 = pow(s2r2, 3);
-    const Real s12r12 = pow(s6r6, 2);
-    return 4.0 * epsilon * (s12r12 - s6r6);
-  }
-}
-
-Real ProximityMatrixCalcs::calcChargeEnergy(int a1, int a2, Real r, Real** aData) {
-  if (r == 0.0) {
-    return 0.0;
-  } else {
-    const Real e = 332.06;
-    return (aData[ATOM_CHARGE][a1] * aData[ATOM_CHARGE][a2] * e) / r;
-  }
-}
-
-Real ProximityMatrixCalcs::calcBlending (Real a, Real b) {
-  if (a * b >= 0) {
-    return sqrt(a*b);
-  } else {
-    return sqrt(-1*a*b);
-  }
 }
 
 // FIXME ...END FUNCTIONS DUPLICATED FROM BRUTEFORCESTEP
@@ -212,7 +143,7 @@ char *ProximityMatrixCalcs::createProximityMatrix() {
     for (int j = 0; j < numMolecules; j++) {
       const int p2Start = molData[MOL_PIDX_START][j];
       const int p2End = molData[MOL_PIDX_COUNT][j] + p2Start;
-      matrix[i*numMolecules + j] = (j != i && ProximityMatrixCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
+      matrix[i*numMolecules + j] = (j != i && SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
     }
   }
   return matrix;
@@ -235,7 +166,7 @@ void ProximityMatrixCalcs::updateProximityMatrix(char *matrix, int i) {
     const int p2Start = molData[MOL_PIDX_START][j];
     const int p2End = molData[MOL_PIDX_COUNT][j] + p2Start;
 
-    const char entry = (j != i && ProximityMatrixCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
+    const char entry = (j != i && SimCalcs::moleculesInRange(p1Start, p1End, p2Start, p2End, atomCoords, bSize, pIdxes, cutoff));
     matrix[i*numMolecules + j] = entry;
     matrix[j*numMolecules + i] = entry;
   }

--- a/src/Metropolis/ProximityMatrixStep.h
+++ b/src/Metropolis/ProximityMatrixStep.h
@@ -1,21 +1,22 @@
 /**
  * ProximityMatrixStep.h
  *
- * A subclass of SimulationStep that uses a "proximity matrix" for energy calculations
+ * A subclass of SimulationStep that uses a "proximity matrix" for energy
+ * calculations
  *
- * We define a "proximity matrix" analogously to an adjacency matrix in graph theory:
- * There is one row and one column for each molecule, and the entry in row i column j
- * is 1 if moleculesInRange() indicates that molecules i and j are in range of each
- * other (and 0 if those molecules are not in range).
+ * We define a "proximity matrix" analogously to an adjacency matrix in graph
+ * theory: There is one row and one column for each molecule, and the entry in
+ * row i column j is 1 if moleculesInRange() indicates that molecules i and j
+ * are in range of each other (and 0 if those molecules are not in range).
  *
- * This matrix is symmetric, since if entry (i,j) indicates that molecules i and j are
- * in range, entry (j,i) should also indicate the same.
+ * This matrix is symmetric, since if entry (i,j) indicates that molecules i
+ * and j are in range, entry (j,i) should also indicate the same.
  *
- * For GPU efficiency, the matrix is linearized as a one-dimensional char array, where
- * entry (i,j) is stored in proximityMatrix[i*numMolecules + j].
+ * For GPU efficiency, the matrix is linearized as a one-dimensional char
+ * array, where entry (i,j) is stored in proximityMatrix[i*numMolecules + j].
  *
- * This is not an especially space-efficient data structure, but it can be updated
- * quickly (in parallel) on the GPU.
+ * This is not an especially space-efficient data structure, but it can be
+ * updated quickly (in parallel) on the GPU.
  *
  * (Future Work: This could be stored as a bit matrix to save space...)
  */
@@ -27,19 +28,22 @@
 
 class ProximityMatrixStep: public SimulationStep {
  public:
-  explicit ProximityMatrixStep(SimBox* box): SimulationStep(box), proximityMatrix(NULL) {}
+  explicit ProximityMatrixStep(SimBox* box): SimulationStep(box),
+                                             proximityMatrix(NULL) {}
   virtual ~ProximityMatrixStep();
-  virtual Real calcSystemEnergy(Real &subLJ, Real &subCharge, int numMolecules);
+  virtual Real calcSystemEnergy(Real &subLJ, Real &subCharge,
+                                int numMolecules);
   virtual Real calcMolecularEnergyContribution(int currMol, int startMol);
   virtual void changeMolecule(int molIdx, SimBox *box);
   virtual void rollback(int molIdx, SimBox *box);
-private:
+ private:
   char *proximityMatrix;
 };
 
 namespace ProximityMatrixCalcs {
 
-  Real calcMolecularEnergyContribution(int currMol, int startMol, char *proximityMatrix);
+  Real calcMolecularEnergyContribution(int currMol, int startMol,
+                                       char *proximityMatrix);
 
   #pragma acc routine vector
   Real calcMoleculeInteractionEnergy (int m1, int m2, int** molData,

--- a/src/Metropolis/ProximityMatrixStep.h
+++ b/src/Metropolis/ProximityMatrixStep.h
@@ -1,0 +1,77 @@
+/**
+ * ProximityMatrixStep.h
+ *
+ * A subclass of SimulationStep that uses a "proximity matrix" for energy calculations
+ *
+ * We define a "proximity matrix" analogously to an adjacency matrix in graph theory:
+ * There is one row and one column for each molecule, and the entry in row i column j
+ * is 1 if moleculesInRange() indicates that molecules i and j are in range of each
+ * other (and 0 if those molecules are not in range).
+ *
+ * This matrix is symmetric, since if entry (i,j) indicates that molecules i and j are
+ * in range, entry (j,i) should also indicate the same.
+ *
+ * For GPU efficiency, the matrix is linearized as a one-dimensional char array, where
+ * entry (i,j) is stored in proximityMatrix[i*numMolecules + j].
+ *
+ * This is not an especially space-efficient data structure, but it can be updated
+ * quickly (in parallel) on the GPU.
+ *
+ * (Future Work: This could be stored as a bit matrix to save space...)
+ */
+
+#ifndef METROPOLIS_PROXIMITYMATRIX_H
+#define METROPOLIS_PROXIMITYMATRIX_H
+
+#include "SimulationStep.h"
+
+class ProximityMatrixStep: public SimulationStep {
+ public:
+  explicit ProximityMatrixStep(SimBox* box): SimulationStep(box), proximityMatrix(NULL) {}
+  virtual ~ProximityMatrixStep();
+  virtual Real calcSystemEnergy(Real &subLJ, Real &subCharge, int numMolecules);
+  virtual Real calcMolecularEnergyContribution(int currMol, int startMol);
+  virtual void changeMolecule(int molIdx, SimBox *box);
+  virtual void rollback(int molIdx, SimBox *box);
+private:
+  char *proximityMatrix;
+};
+
+namespace ProximityMatrixCalcs {
+
+  Real calcMolecularEnergyContribution(int currMol, int startMol, char *proximityMatrix);
+
+  #pragma acc routine seq
+  bool moleculesInRange(int p1Start, int p1End, int p2Start, int p2End,
+                        Real** atomCoords, Real* bSize, int* primaryIndexes,
+                        Real cutoff);
+
+  #pragma acc routine seq
+  Real calcAtomDistSquared(int a1, int a2, Real** aCoords,
+                           Real* bSize);
+
+  #pragma acc routine seq
+  Real makePeriodic(Real x, int dimension, Real* bSize);
+
+  #pragma acc routine vector
+  Real calcMoleculeInteractionEnergy (int m1, int m2, int** molData,
+                                      Real** aData, Real** aCoords,
+                                      Real* bSize);
+
+  #pragma acc routine seq
+  Real calcLJEnergy(int a1, int a2, Real r2, Real** aData);
+
+  #pragma acc routine seq
+  Real calcChargeEnergy(int a1, int a2, Real r, Real** aData);
+
+  #pragma acc routine seq
+  Real calcBlending (Real a, Real b);
+
+  char *createProximityMatrix();
+
+  void updateProximityMatrix(char *matrix, int i);
+
+  void freeProximityMatrix(char *matrix);
+}
+
+#endif

--- a/src/Metropolis/ProximityMatrixStep.h
+++ b/src/Metropolis/ProximityMatrixStep.h
@@ -41,31 +41,10 @@ namespace ProximityMatrixCalcs {
 
   Real calcMolecularEnergyContribution(int currMol, int startMol, char *proximityMatrix);
 
-  #pragma acc routine seq
-  bool moleculesInRange(int p1Start, int p1End, int p2Start, int p2End,
-                        Real** atomCoords, Real* bSize, int* primaryIndexes,
-                        Real cutoff);
-
-  #pragma acc routine seq
-  Real calcAtomDistSquared(int a1, int a2, Real** aCoords,
-                           Real* bSize);
-
-  #pragma acc routine seq
-  Real makePeriodic(Real x, int dimension, Real* bSize);
-
   #pragma acc routine vector
   Real calcMoleculeInteractionEnergy (int m1, int m2, int** molData,
                                       Real** aData, Real** aCoords,
                                       Real* bSize);
-
-  #pragma acc routine seq
-  Real calcLJEnergy(int a1, int a2, Real r2, Real** aData);
-
-  #pragma acc routine seq
-  Real calcChargeEnergy(int a1, int a2, Real r, Real** aData);
-
-  #pragma acc routine seq
-  Real calcBlending (Real a, Real b);
 
   char *createProximityMatrix();
 

--- a/src/Metropolis/Simulation.cpp
+++ b/src/Metropolis/Simulation.cpp
@@ -19,6 +19,7 @@
 #include "SimulationArgs.h"
 #include "SimulationStep.h"
 #include "BruteForceStep.h"
+#include "ProximityMatrixStep.h"
 #include "Box.h"
 #include "Metropolis/Utilities/MathLibrary.h"
 #include "Metropolis/Utilities/Parsing.h"
@@ -119,7 +120,8 @@ void Simulation::run() {
   bool parallel = args.simulationMode == SimulationMode::Parallel;
   SimBox* sb = builder.build(box);
   GPUCopy::setParallel(parallel);
-  SimulationStep *simStep = new BruteForceStep(sb);
+  //SimulationStep *simStep = new BruteForceStep(sb); // FIXME
+  SimulationStep *simStep = new ProximityMatrixStep(sb); // FIXME
   GPUCopy::copyIn(sb);
   // SimCalcs::setSB(sb);
   //Calculate original starting energy for the entire system

--- a/src/Metropolis/Simulation.cpp
+++ b/src/Metropolis/Simulation.cpp
@@ -120,8 +120,18 @@ void Simulation::run() {
   bool parallel = args.simulationMode == SimulationMode::Parallel;
   SimBox* sb = builder.build(box);
   GPUCopy::setParallel(parallel);
-  //SimulationStep *simStep = new BruteForceStep(sb); // FIXME
-  SimulationStep *simStep = new ProximityMatrixStep(sb); // FIXME
+  SimulationStep *simStep;
+  if (args.strategy == Strategy::BruteForce) {
+    log.verbose("Using brute force strategy for energy calculations");
+    simStep = new BruteForceStep(sb);
+  } else if (args.strategy == Strategy::ProximityMatrix) {
+    log.verbose("Using proximity matrix strategy for energy calculations");
+    simStep = new ProximityMatrixStep(sb);
+  } else {
+    log.verbose("No energy calculation strategy specified, defaulting to "
+                "brute force");
+    simStep = new BruteForceStep(sb);
+  }
   GPUCopy::copyIn(sb);
   // SimCalcs::setSB(sb);
   //Calculate original starting energy for the entire system

--- a/src/Metropolis/SimulationArgs.cpp
+++ b/src/Metropolis/SimulationArgs.cpp
@@ -1,8 +1,8 @@
 #include "SimulationArgs.h"
 
 /** Convert a string strategy to a SimulationStrategy type */
-SimulationStrategy Strategy::getStrategy(std::string type) {
-  if (type == "brute" || type == "brute-foce") {
+SimulationStrategy Strategy::fromString(std::string type) {
+  if (type == "brute" || type == "brute-force") {
     return Strategy::BruteForce;
   } else if (type == "prox" || type == "proximity-matrix") {
     return Strategy::ProximityMatrix;

--- a/src/Metropolis/SimulationArgs.cpp
+++ b/src/Metropolis/SimulationArgs.cpp
@@ -1,0 +1,12 @@
+#include "SimulationArgs.h"
+
+/** Convert a string strategy to a SimulationStrategy type */
+SimulationStrategy Strategy::getStrategy(std::string type) {
+  if (type == "brute" || type == "brute-foce") {
+    return Strategy::BruteForce;
+  } else if (type == "prox" || type == "proximity-matrix") {
+    return Strategy::ProximityMatrix;
+  } else {
+    return Strategy::Unknown;
+  }
+}

--- a/src/Metropolis/SimulationArgs.h
+++ b/src/Metropolis/SimulationArgs.h
@@ -48,7 +48,7 @@ namespace Strategy {
     Unknown
   };
 
-  Type getStrategy(std::string type);
+  Type fromString(std::string type);
 }
 typedef Strategy::Type SimulationStrategy;
 

--- a/src/Metropolis/SimulationArgs.h
+++ b/src/Metropolis/SimulationArgs.h
@@ -1,108 +1,124 @@
-/// @file SimulationArgs.h
-///
-/// Contains the definitions for the data structures and data types used to communicate
-/// command-line information to the simulation.
+/**
+ * SimulationArgs.h
+ * 
+ * Contains the definitions for the data structures and data types used to
+ * communicate command-line information to the simulation.
+ */
 
 #ifndef METROSIM_SIMULATION_ARGS_H
 #define METROSIM_SIMULATION_ARGS_H
 
 #include <string>
 
-/// Contains SimulationModeType enum
-namespace SimulationMode
-{
-	/// Specifies whether to run the simulation on the CPU or the GPU.
-	///
-	/// @note If default is specified, then the program will utilize device
-	///   querying to decide whether to run in serial or parallel.
-	enum Type
-	{
-		/// Run the simulation using a default mode.
-		Default,
-
-		/// Run the simulation serially on the CPU.
-		Serial,
-
-		/// Run the simulation in parallel on the GPU. The simulation
-		/// will not run if a valid CUDA device is not found.
-		Parallel
-	};
+/** Contains SimulationModeType enumeration */
+namespace SimulationMode {
+  /**
+   * Specifies whether to run the simulation on the CPU or the GPU.
+   *
+   * @note If default is specified, then the program will utilize device
+   *   querying to decide whether to run in serial or parallel.
+   */
+  enum Type {
+    Default,
+    Serial,
+    Parallel
+  };
 }
 
-/// Allows easy access to the SimulationMode::Type enumeration.
+/** Allows easy access to the SimulationMode::Type enumeration. */
 typedef SimulationMode::Type SimulationModeType;
 
-namespace InputFile
-{
-	enum Type
-	{
-		Unknown,
-
-		Configuration,
-
-		State
-	};
+/** Enumeration for the type of input file */
+namespace InputFile {
+  enum Type {
+    Unknown,
+    Configuration,
+    State
+  };
 }
 
 typedef InputFile::Type InputFileType;
 
-/// A list of commands and arguments that define the settings for the
-/// simulation set by the user.
-///
-/// @remarks This is the data structure that will pass information read
-///   from the command line to the simulation.
-struct SimulationArgs
-{
-	/// A relative file path to the input file specified by the user.
-	/// @note This file path may lead to different types of files, such
-	///     as configuration files or state files.
-	std::string filePath;
+/** Enumeration for the simulation strategy */
+namespace Strategy {
+  enum Type {
+    Default,
+    BruteForce,
+    ProximityMatrix,
+    Unknown
+  };
 
-	/// The type of input file given to the program by the user.
-	InputFileType fileType;
+  Type getStrategy(std::string type);
+}
+typedef Strategy::Type SimulationStrategy;
 
-	/// An optional name given to the current simulation run by the user.
-	std::string simulationName;
+/**
+ * A list of commands and arguments that define the settings for the
+ * simulation set by the user.
+ * 
+ * @remarks This is the data structure that will pass information read
+ *   from the command line to the simulation.
+ */
+struct SimulationArgs {
+  /**
+   * A relative file path to the input file specified by the user.
+   * @note This file path may lead to different types of files, such
+   *     as configuration files or state files.
+   */
+  std::string filePath;
 
-	/// The simulation mode that determines whether to run on the
-	/// CPU or the GPU.
-	SimulationModeType simulationMode;
+  /** The type of input file given to the program by the user. */
+  InputFileType fileType;
 
-	/// If executing in parallel, the index of the graphics card being
-	/// used to run the simulation. Set to DEVICE_ANY if running 
-	/// using the CPU.
-	int deviceIndex;
+  /** An optional name given to the current simulation run by the user. */
+  std::string simulationName;
 
-	/// The number of simulation steps to execute in the current run.
-	int stepCount;
+  /** Determines whether to run on the CPU or the GPU. */
+  SimulationModeType simulationMode;
 
-	/// Whether or not program prints to cout 
-	///		(silenced for integration tests)
-	bool verboseOutput;
+  /** Determines the particular strategy used for energy calculations */
+  SimulationStrategy strategy;
 
-	/// Enables or disables use of linked-list neigborlist in calcs
-	bool useNeighborList;
+  /**
+   * If executing in parallel, the index of the graphics card being
+   * used to run the simulation. Set to DEVICE_ANY if running 
+   * using the CPU.
+   */
+  int deviceIndex;
 
-	/// The number of simultion steps between updating the neighborlist
-	int neighborListInterval;
+  /** The number of simulation steps to execute in the current run. */
+  int stepCount;
 
-	/// The number of simulation steps between status updates printed to
-	/// the console. A value of 0 means that status updates are only
-	/// printed at the beginning and the end of the simulation.
-	int statusInterval;
+  /** If true, prints to cout (silenced for integration tests) */
+  bool verboseOutput;
 
-	/// The number of simulation steps between state file saves.
-	/// @note This interval must be a non-negative number, and specifying
-	///    an interval of 0 means a single state file should be saved
-	///    at the very end of the simulation (which is the default
-	///    behavior with no interval specified).
-	int stateInterval;
+  /** Enables or disables use of linked-list neigborlist in calcs */
+  bool useNeighborList;
 
-	/// Path to directory for PDB output data
-	std::string pdbOutputPath;
+  /** The number of simultion steps between updating the neighborlist */
+  int neighborListInterval;
 
-	/// Path to directory for simulation state data
-	std::string stateOutputPath;
+  /**
+   * The number of simulation steps between status updates printed to
+   * the console. A value of 0 means that status updates are only
+   * printed at the beginning and the end of the simulation.
+   */
+  int statusInterval;
+
+  /**
+   * The number of simulation steps between state file saves.
+   * @note This interval must be a non-negative number, and specifying
+   *    an interval of 0 means a single state file should be saved
+   *    at the very end of the simulation (which is the default
+   *    behavior with no interval specified).
+   */
+  int stateInterval;
+
+  /** Path to directory for PDB output data */
+  std::string pdbOutputPath;
+
+  /** Path to directory for simulation state data */
+  std::string stateOutputPath;
 };
 
 #endif

--- a/src/Metropolis/SimulationStep.cpp
+++ b/src/Metropolis/SimulationStep.cpp
@@ -47,7 +47,6 @@ Real SimulationStep::calcSystemEnergy(Real &subLJ, Real &subCharge,
 SimBox* SimCalcs::sb;
 int SimCalcs::on_gpu;
 
-
 bool SimCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
                                        int p2End, Real** atomCoords,
                                        Real* bSize, int* primaryIndexes,
@@ -57,14 +56,15 @@ bool SimCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
     int p1 = primaryIndexes[p1Idx];
     for (int p2Idx = p2Start; p2Idx < p2End; p2Idx++) {
       int p2 = primaryIndexes[p2Idx];
-      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <= cutoff * cutoff);
+      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <=
+              cutoff * cutoff);
     }
   }
   return out;
 }
 
 Real SimCalcs::calcAtomDistSquared(int a1, int a2, Real** aCoords,
-                                          Real* bSize) {
+                                   Real* bSize) {
   Real dx = makePeriodic(aCoords[X_COORD][a2] - aCoords[X_COORD][a1],
                          X_COORD, bSize);
   Real dy = makePeriodic(aCoords[Y_COORD][a2] - aCoords[Y_COORD][a1],
@@ -118,7 +118,8 @@ Real SimCalcs::makePeriodic(Real x, int dimension, Real* bSize) {
   return x;
 }
 
-void SimCalcs::rotateAtom(int aIdx, int pivotIdx, Real rotX, Real rotY, Real rotZ, Real** aCoords) {
+void SimCalcs::rotateAtom(int aIdx, int pivotIdx, Real rotX, Real rotY,
+                          Real rotZ, Real** aCoords) {
   Real pX = aCoords[X_COORD][pivotIdx];
   Real pY = aCoords[Y_COORD][pivotIdx];
   Real pZ = aCoords[Z_COORD][pivotIdx];
@@ -177,8 +178,9 @@ void SimCalcs::changeMolecule(int molIdx) {
   int* pIdxes = GPUCopy::primaryIndexesPtr();
   int** molData = GPUCopy::moleculeDataPtr();
 
-  // do the move here
-  #pragma acc parallel loop deviceptr(aCoords, rBCoords) if(on_gpu)
+  // Do the move here
+  #pragma acc parallel loop deviceptr(aCoords, rBCoords) \
+      if (on_gpu)
   for (int i = 0; i < molLen; i++) {
     for (int j = 0; j < NUM_DIMENSIONS; j++) {
       rBCoords[j][i] = aCoords[j][molStart + i];
@@ -189,7 +191,8 @@ void SimCalcs::changeMolecule(int molIdx) {
     translateAtom(molStart + i, deltaX, deltaY, deltaZ, aCoords);
   }
 
-  #pragma acc parallel loop deviceptr(aCoords, molData, pIdxes, bSize) if(on_gpu)
+  #pragma acc parallel loop deviceptr(aCoords, molData, pIdxes, bSize) \
+      if (on_gpu)
   for (int i = 0; i < 1; i++) {
     aCoords[0][molStart + vertexIdx] += deltaX;
     aCoords[1][molStart + vertexIdx] += deltaY;
@@ -198,13 +201,15 @@ void SimCalcs::changeMolecule(int molIdx) {
   }
 }
 
-void SimCalcs::translateAtom(int aIdx, Real dX, Real dY, Real dZ, Real** aCoords) {
+void SimCalcs::translateAtom(int aIdx, Real dX, Real dY, Real dZ,
+                             Real** aCoords) {
   aCoords[X_COORD][aIdx] += dX;
   aCoords[Y_COORD][aIdx] += dY;
   aCoords[Z_COORD][aIdx] += dZ;
 }
 
-void SimCalcs::keepMoleculeInBox(int molIdx, Real** aCoords, int** molData, int* pIdxes, Real* bSize) {
+void SimCalcs::keepMoleculeInBox(int molIdx, Real** aCoords, int** molData,
+                                 int* pIdxes, Real* bSize) {
   int start = molData[MOL_START][molIdx];
   int end = start + molData[MOL_LEN][molIdx];
   int pIdx = pIdxes[molData[MOL_PIDX_START][molIdx]];
@@ -231,7 +236,7 @@ void SimCalcs::rollback(int molIdx) {
   Real** aCoords = GPUCopy::atomCoordinatesPtr();
   Real** rBCoords = GPUCopy::rollBackCoordinatesPtr();
 
-  #pragma acc parallel loop deviceptr(aCoords, rBCoords) if(on_gpu)
+  #pragma acc parallel loop deviceptr(aCoords, rBCoords) if (on_gpu)
   for (int i = 0; i < NUM_DIMENSIONS; i++) {
     #pragma acc loop independent 
     for (int j = 0; j < molLen; j++) {

--- a/src/Metropolis/SimulationStep.cpp
+++ b/src/Metropolis/SimulationStep.cpp
@@ -48,6 +48,76 @@ SimBox* SimCalcs::sb;
 int SimCalcs::on_gpu;
 
 
+bool SimCalcs::moleculesInRange(int p1Start, int p1End, int p2Start,
+                                       int p2End, Real** atomCoords,
+                                       Real* bSize, int* primaryIndexes,
+                                       Real cutoff) {
+  bool out = false;
+  for (int p1Idx = p1Start; p1Idx < p1End; p1Idx++) {
+    int p1 = primaryIndexes[p1Idx];
+    for (int p2Idx = p2Start; p2Idx < p2End; p2Idx++) {
+      int p2 = primaryIndexes[p2Idx];
+      out |= (calcAtomDistSquared(p1, p2, atomCoords, bSize) <= cutoff * cutoff);
+    }
+  }
+  return out;
+}
+
+Real SimCalcs::calcAtomDistSquared(int a1, int a2, Real** aCoords,
+                                          Real* bSize) {
+  Real dx = makePeriodic(aCoords[X_COORD][a2] - aCoords[X_COORD][a1],
+                         X_COORD, bSize);
+  Real dy = makePeriodic(aCoords[Y_COORD][a2] - aCoords[Y_COORD][a1],
+                         Y_COORD, bSize);
+  Real dz = makePeriodic(aCoords[Z_COORD][a2] - aCoords[Z_COORD][a1],
+                         Z_COORD, bSize);
+
+  return dx * dx + dy * dy + dz * dz;
+}
+
+Real SimCalcs::calcLJEnergy(int a1, int a2, Real r2, Real** aData) {
+  if (r2 == 0.0) {
+    return 0.0;
+  } else {
+    const Real sigma = SimCalcs::calcBlending(aData[ATOM_SIGMA][a1],
+        aData[ATOM_SIGMA][a2]);
+    const Real epsilon = SimCalcs::calcBlending(aData[ATOM_EPSILON][a1],
+        aData[ATOM_EPSILON][a2]);
+
+    const Real s2r2 = pow(sigma, 2) / r2;
+    const Real s6r6 = pow(s2r2, 3);
+    const Real s12r12 = pow(s6r6, 2);
+    return 4.0 * epsilon * (s12r12 - s6r6);
+  }
+}
+
+Real SimCalcs::calcChargeEnergy(int a1, int a2, Real r, Real** aData) {
+  if (r == 0.0) {
+    return 0.0;
+  } else {
+    const Real e = 332.06;
+    return (aData[ATOM_CHARGE][a1] * aData[ATOM_CHARGE][a2] * e) / r;
+  }
+}
+
+Real SimCalcs::calcBlending (Real a, Real b) {
+  if (a * b >= 0) {
+    return sqrt(a*b);
+  } else {
+    return sqrt(-1*a*b);
+  }
+}
+
+Real SimCalcs::makePeriodic(Real x, int dimension, Real* bSize) {
+  Real dimLength = bSize[dimension];
+
+  int lt = (x < -0.5 * dimLength); // 1 or 0
+  x += lt * dimLength;
+  int gt = (x > 0.5 * dimLength);  // 1 or 0
+  x -= gt * dimLength;
+  return x;
+}
+
 void SimCalcs::rotateAtom(int aIdx, int pivotIdx, Real rotX, Real rotY, Real rotZ, Real** aCoords) {
   Real pX = aCoords[X_COORD][pivotIdx];
   Real pY = aCoords[Y_COORD][pivotIdx];

--- a/src/Metropolis/SimulationStep.h
+++ b/src/Metropolis/SimulationStep.h
@@ -74,6 +74,76 @@ namespace SimCalcs {
   extern int on_gpu;
 
   /**
+   * Determines whether or not two molecule's primaryIndexes are within the
+   * cutoff range of one another.
+   *
+   * @param p1Start The index of the first primary index from molecule 1.
+   * @param p1End index of the last primary index from molecule 1,  + 1.
+   * @param p2Start index of the first primary index from molecule 2.
+   * @param p2End index of the last primary index from molecule 2,  + 1.
+   * @param atomCoords The coordinates of the atoms to check.
+   * @return true if the molecules are in range, false otherwise.
+   */
+  #pragma acc routine seq
+  bool moleculesInRange(int p1Start, int p1End, int p2Start, int p2End,
+                        Real** atomCoords, Real* bSize, int* primaryIndexes,
+                        Real cutoff);
+
+  /**
+   * Calculates the square of the distance between two atoms.
+   *
+   * @param a1 The atom index of the first atom.
+   * @param a2 The atom index of the second atom.
+   * @return The square of the distance between the atoms.
+   */
+  #pragma acc routine seq
+  Real calcAtomDistSquared(int a1, int a2, Real** aCoords,
+                           Real* bSize);
+
+  /**
+   * Calculates the Lennard - Jones potential between two atoms.
+   *
+   * @param a1  The atom index of the first atom.
+   * @param a2  The atom index of the second atom.
+   * @param r2  The distance between the atoms, squared.
+   * @return The Lennard - Jones potential from the two atoms' interaction.
+   */
+  #pragma acc routine seq
+  Real calcLJEnergy(int a1, int a2, Real r2, Real** aData);
+
+  /**
+   * Given a distance, makes the distance periodic to mitigate distances
+   * greater than half the length of the box.
+   *
+   * @param x The measurement to make periodic.
+   * @param dimension The dimension the measurement must be made periodic in.
+   * @return The measurement, scaled to be periodic.
+   */
+  #pragma acc routine seq
+  Real makePeriodic(Real x, int dimension, Real* bSize);
+
+  /**
+   * Calculates the Coloumb potential between two atoms.
+   *
+   * @param a1 The atom index of the first atom.
+   * @param a2 The atom index of the second atom.
+   * @param r  The distance between the atoms.
+   * @return The Coloumb potential from the two atoms' interaction.
+   */
+  #pragma acc routine seq
+  Real calcChargeEnergy(int a1, int a2, Real r, Real** aData);
+
+  /**
+   * Calculates the geometric mean of two real numbers.
+   *
+   * @param a The first real number.
+   * @param b The second real number.
+   * @return sqrt(|a*b|), the geometric mean of the two numbers.
+   */
+  #pragma acc routine seq
+  Real calcBlending (Real a, Real b);
+
+  /**
    * Given a molecule to change, randomly moves the molecule within the box.
    * This performs a translation and a rotation, and saves the old position.
    *

--- a/src/Metropolis/SimulationStep.h
+++ b/src/Metropolis/SimulationStep.h
@@ -40,7 +40,7 @@ class SimulationStep {
    *
    * @param molIdx The index of the molecule to change.
    */
-  void changeMolecule(int molIdx, SimBox *box);
+  virtual void changeMolecule(int molIdx, SimBox *box);
 
 
   /**
@@ -49,7 +49,7 @@ class SimulationStep {
    *
    * @param molIdx The index of the molecule to change.
    */
-  void rollback(int molIdx, SimBox *box);
+  virtual void rollback(int molIdx, SimBox *box);
 
 
   /**
@@ -59,7 +59,7 @@ class SimulationStep {
    * @param subCharge Initial Coulomb energy.
    * @return The total energy of the box.
    */
-  Real calcSystemEnergy(Real &subLJ, Real &subCharge, int numMolecules);
+  virtual Real calcSystemEnergy(Real &subLJ, Real &subCharge, int numMolecules);
 };
 
 /**

--- a/src/Metropolis/Utilities/ConfigScanner.cpp
+++ b/src/Metropolis/Utilities/ConfigScanner.cpp
@@ -10,268 +10,277 @@
 
 
 ConfigScanner::ConfigScanner() {
-	enviro = Environment();
-	numOfSteps = 0;
-	useStatefileSetup = false;
-	useZMatrixSetup = false;
+  enviro = Environment();
+  numOfSteps = 0;
+  useStatefileSetup = false;
+  useZMatrixSetup = false;
 }
 
 
 bool ConfigScanner::readInConfig(string configpath) {
-	isSafeToContinue = true;
-	enviro = Environment();
-	numOfSteps = 0;
+  isSafeToContinue = true;
+  enviro = Environment();
+  numOfSteps = 0;
 
-	configPath = configpath;
-	if (configPath.empty()) {
-		std::cerr << "Configuration File path is empty" << std::endl;
-		return false;
-	}
+  configPath = configpath;
+  if (configPath.empty()) {
+    std::cerr << "Configuration File path is empty" << std::endl;
+    return false;
+  }
 
-	ifstream configscanner(configPath.c_str());
-	if (!configscanner.is_open()) {
-		std::cerr << "Unable to open configuration file (" << configPath << ")"
-			<< std::endl;
-		return false;
-	}
-	string line;
+  ifstream configscanner(configPath.c_str());
+  if (!configscanner.is_open()) {
+    std::cerr << "Unable to open configuration file (" << configPath << ")"
+      << std::endl;
+    return false;
+  }
+  string line;
 
-	while (configscanner.good()) {
-		getline(configscanner, line);
-		trim(line);
+  while (configscanner.good()) {
+    getline(configscanner, line);
+    trim(line);
 
-		// Ignore blank lines and comments
-		if (line.empty() || line[0] == '#' || line[0] == ';') {
-			continue;
-		}
+    // Ignore blank lines and comments
+    if (line.empty() || line[0] == '#' || line[0] == ';') {
+      continue;
+    }
 
-		// Sections are supported, but don't have any additional functionality
-		if (line[0] == '[' && line.find(']') == line.length()) {
-			continue;
-		}
+    // Sections are supported, but don't have any additional functionality
+    if (line[0] == '[' && line.find(']') == line.length()) {
+      continue;
+    }
 
-		int splitPos = line.find('=');
-		if (splitPos == -1) {
-			throwScanError("Error: Configuration File not well formed.\n"
-				"Offending line: \"" + line + "\"");
-			return false;
-		}
-		string key = line.substr(0, splitPos);
-		string value = line.substr(splitPos+1, line.length());
+    int splitPos = line.find('=');
+    if (splitPos == -1) {
+      throwScanError("Error: Configuration File not well formed.\n"
+        "Offending line: \"" + line + "\"");
+      return false;
+    }
+    string key = line.substr(0, splitPos);
+    string value = line.substr(splitPos+1, line.length());
 
-		// Assign attributes based on key
-		if (key == "x") {
-			if (value.length() > 0) {
-				enviro.x = atof(value.c_str());
-			} else {
-				throwScanError("Error: Config File: Missing environment X value.");
-				return false;
-			}
-		} else if (key == "y") {
-			if (value.length() > 0) {
-				enviro.y = atof(value.c_str());
-			} else {
-				throwScanError("Error: Config File: Missing environment Y value.");
-				return false;
-			}
-		} else if (key == "z") {
-			if (value.length() > 0) {
-				enviro.z = atof(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment z value.");
-				return false;
-			}
-		} else if (key == "temp") {
-			if (value.length() > 0) {
-				enviro.temp = atof(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment temperature value.");
-				return false;
-			}
-		} else if (key == "max-translation") {
-			if (value.length() > 0) {
-				enviro.maxTranslation = atof(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment max translation value.");
-				return false;
-				}
-		} else if (key == "steps") {
-				if (value.length() > 0) {
-					numOfSteps = atoi(value.c_str());
-				} else {
-					throwScanError("Configuration file not well formed. Missing number of steps value.");
-					return false;
-				}
-		} else if (key == "molecules") {
-			if (value.length() > 0) {
-				enviro.numOfMolecules = atoi(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing number of molecules value.");
-				return false;
-			}
-		} else if (key == "opla.par") {
-			if (value.length() > 0) {
-				oplsuaparPath = value;
-			} else {
-				throwScanError("Configuration file not well formed. Missing oplsuapar path value.");
-				return false;
-			}
-		} else if (key == "z-matrix") {
-			if (value.length() > 0) {
-				zmatrixPath = value;
-				useZMatrixSetup = true;
-				useStatefileSetup = true;
-			} else {
-				throwScanError("INFO: Configuration file not well formed. Missing z-matrix path value. Attempting to rely on prior state information...");
-				isSafeToContinue = false; //now that it is false, check if there is a state file
-				useZMatrixSetup = false;
-				useStatefileSetup = true;
-			}
-		} else if (key == "state-input") {
-			if (value.length() > 0) {
-				statePath = value;
-				useZMatrixSetup = false; //we will go ahead and use the statefile, since the path was provided
-				useStatefileSetup = true;
-			} else if (isSafeToContinue == false) { // If no z matrix was provided, and no state file, there is a problem.
-				throwScanError("Configuration file not well formed. Missing value pointing to prior state file path. Cannot safely continue with program execution.");
-				useStatefileSetup = false; //we can't even hope to find the state file, so don't use it
-				useZMatrixSetup = false;
-				return false; //preferable to simply exiting, as we want to give the program a chance to do...whatever?
-			} else { // If we don't have a state file, but do have a z-matrix, use the z-matrix.
-				throwScanError("INFO: Value pointing to prior state file path not found in main config file. Environment setup defaulting to clean simulation.");
-				useZMatrixSetup = true; //revert to using the Zmatrix file for all setup
-				useStatefileSetup = false;
-				isSafeToContinue = true;
-			}
-		} else if (key == "state-output") {
-			if (value.length() > 0) {
-				stateOutputPath = value;
-			} else {
-				throwScanError("Configuration file not well formed. Missing state file output path value.");
-				return false;
-			}
-		} else if (key == "pdb-output") {
-			if (value.length() > 0) {
-				pdbOutputPath = value;
-			} else {
-				throwScanError("Configuration file not well formed. Missing PDB output path value.");
-				return false;
-			}
-		} else if (key == "cutoff") {
-			if (value.length() > 0) {
-				enviro.cutoff = atof(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment cutoff value.");
-				return false;
-			}
-		} else if (key == "max-rotation") {
-			if (value.length() > 0) {
-				enviro.maxRotation = atof(value.c_str());
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment max rotation value.");
-				return false;
-			}
-		} else if (key == "random-seed") {
-			if (value.length() > 0) {
-				enviro.randomseed=atoi(value.c_str());
-			} else {
-				enviro.randomseed = (unsigned int) time(NULL);
-			}
-		} else if (key == "primary-atom") {
-			if (value.length() > 0) {
-				// Convert to a zero-based index
-				parsePrimaryIndexDefinitions(value);
-			} else {
-				throwScanError("Configuration file not well formed. Missing environment primary atom index value.");
-				return false;
-			}
-		} else if (key == "sim-name") {
-			if (value.length() > 0) {
-				simName = value;
-			}
-		} else {
-			throwScanError("Unexpected key encountered: " + key);
-			return false;
-		}
-	}
-	configscanner.close();
-	return true;
+    // Assign attributes based on key
+    if (key == "x") {
+      if (value.length() > 0) {
+        enviro.x = atof(value.c_str());
+      } else {
+        throwScanError("Error: Config File: Missing environment X value.");
+        return false;
+      }
+    } else if (key == "y") {
+      if (value.length() > 0) {
+        enviro.y = atof(value.c_str());
+      } else {
+        throwScanError("Error: Config File: Missing environment Y value.");
+        return false;
+      }
+    } else if (key == "z") {
+      if (value.length() > 0) {
+        enviro.z = atof(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing environment z value.");
+        return false;
+      }
+    } else if (key == "temp") {
+      if (value.length() > 0) {
+        enviro.temp = atof(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing environment temperature value.");
+        return false;
+      }
+    } else if (key == "max-translation") {
+      if (value.length() > 0) {
+        enviro.maxTranslation = atof(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing environment max translation value.");
+        return false;
+        }
+    } else if (key == "steps") {
+        if (value.length() > 0) {
+          numOfSteps = atoi(value.c_str());
+        } else {
+          throwScanError("Configuration file not well formed. Missing number of steps value.");
+          return false;
+        }
+    } else if (key == "molecules") {
+      if (value.length() > 0) {
+        enviro.numOfMolecules = atoi(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing number of molecules value.");
+        return false;
+      }
+    } else if (key == "opla.par") {
+      if (value.length() > 0) {
+        oplsuaparPath = value;
+      } else {
+        throwScanError("Configuration file not well formed. Missing oplsuapar path value.");
+        return false;
+      }
+    } else if (key == "z-matrix") {
+      if (value.length() > 0) {
+        zmatrixPath = value;
+        useZMatrixSetup = true;
+        useStatefileSetup = true;
+      } else {
+        throwScanError("INFO: Configuration file not well formed. Missing z-matrix path value. Attempting to rely on prior state information...");
+        isSafeToContinue = false; //now that it is false, check if there is a state file
+        useZMatrixSetup = false;
+        useStatefileSetup = true;
+      }
+    } else if (key == "state-input") {
+      if (value.length() > 0) {
+        statePath = value;
+        useZMatrixSetup = false; //we will go ahead and use the statefile, since the path was provided
+        useStatefileSetup = true;
+      } else if (isSafeToContinue == false) { // If no z matrix was provided, and no state file, there is a problem.
+        throwScanError("Configuration file not well formed. Missing value pointing to prior state file path. Cannot safely continue with program execution.");
+        useStatefileSetup = false; //we can't even hope to find the state file, so don't use it
+        useZMatrixSetup = false;
+        return false; //preferable to simply exiting, as we want to give the program a chance to do...whatever?
+      } else { // If we don't have a state file, but do have a z-matrix, use the z-matrix.
+        throwScanError("INFO: Value pointing to prior state file path not found in main config file. Environment setup defaulting to clean simulation.");
+        useZMatrixSetup = true; //revert to using the Zmatrix file for all setup
+        useStatefileSetup = false;
+        isSafeToContinue = true;
+      }
+    } else if (key == "state-output") {
+      if (value.length() > 0) {
+        stateOutputPath = value;
+      } else {
+        throwScanError("Configuration file not well formed. Missing state file output path value.");
+        return false;
+      }
+    } else if (key == "pdb-output") {
+      if (value.length() > 0) {
+        pdbOutputPath = value;
+      } else {
+        throwScanError("Configuration file not well formed. Missing PDB output path value.");
+        return false;
+      }
+    } else if (key == "cutoff") {
+      if (value.length() > 0) {
+        enviro.cutoff = atof(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing environment cutoff value.");
+        return false;
+      }
+    } else if (key == "max-rotation") {
+      if (value.length() > 0) {
+        enviro.maxRotation = atof(value.c_str());
+      } else {
+        throwScanError("Configuration file not well formed. Missing environment max rotation value.");
+        return false;
+      }
+    } else if (key == "random-seed") {
+      if (value.length() > 0) {
+        enviro.randomseed=atoi(value.c_str());
+      } else {
+        enviro.randomseed = (unsigned int) time(NULL);
+      }
+    } else if (key == "primary-atom") {
+      if (value.length() > 0) {
+        // Convert to a zero-based index
+        parsePrimaryIndexDefinitions(value);
+      } else {
+        throwScanError("Configuration file not well formed. Missing "
+                       "environment primary atom index value.");
+        return false;
+      }
+    } else if (key == "sim-name") {
+      if (value.length() > 0) {
+        simName = value;
+      }
+    } else if (key == "strategy") {
+      if (value.length() > 0) {
+        strategy = value;
+      }
+    } else {
+      throwScanError("Unexpected key encountered: " + key);
+      return false;
+    }
+  }
+  configscanner.close();
+  return true;
 }
 
 void ConfigScanner::parsePrimaryIndexDefinitions(string definitions) {
-	*enviro.primaryAtomIndexConfigLine = definitions;
-	char *indexVector;
-	char *charLine = (char *) malloc(sizeof(char) * (definitions.size()+1));
-	strcpy(charLine, definitions.c_str());
-	indexVector = strtok(charLine, ",");
+  *enviro.primaryAtomIndexConfigLine = definitions;
+  char *indexVector;
+  char *charLine = (char *) malloc(sizeof(char) * (definitions.size()+1));
+  strcpy(charLine, definitions.c_str());
+  indexVector = strtok(charLine, ",");
 
-	for (int i = 0; indexVector ; i++) {
-		std::string sIndexVector = indexVector;
-		enviro.primaryAtomIndexDefinitions++;
-		char* c;
-		if ((c=strchr(indexVector, '[')) != NULL) {
+  for (int i = 0; indexVector ; i++) {
+    std::string sIndexVector = indexVector;
+    enviro.primaryAtomIndexDefinitions++;
+    char* c;
+    if ((c=strchr(indexVector, '[')) != NULL) {
 
-			indexVector = (indexVector + 1);
-		    while ((c=strchr(indexVector, ']')) == NULL) {
-				int currentPrimaryIndex = atoi(indexVector);
-				(*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
-				(*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
-				indexVector = strtok(NULL, ",");
-			}
-	
-			*c = '\0';
-			int currentPrimaryIndex = atoi(indexVector);
-			(*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
-			(*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
-			indexVector =strtok(NULL, ",");
-			continue;
-		}
+      indexVector = (indexVector + 1);
+        while ((c=strchr(indexVector, ']')) == NULL) {
+        int currentPrimaryIndex = atoi(indexVector);
+        (*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
+        (*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
+        indexVector = strtok(NULL, ",");
+      }
+  
+      *c = '\0';
+      int currentPrimaryIndex = atoi(indexVector);
+      (*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
+      (*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
+      indexVector =strtok(NULL, ",");
+      continue;
+    }
 
-		int currentPrimaryIndex = atoi(indexVector);
-		(*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
-		(*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
-		indexVector = strtok(NULL, ",");
-	}
+    int currentPrimaryIndex = atoi(indexVector);
+    (*(enviro.primaryAtomIndexArray)).push_back(new std::vector<int>);
+    (*(*(enviro.primaryAtomIndexArray))[i]).push_back(currentPrimaryIndex - 1);
+    indexVector = strtok(NULL, ",");
+  }
 
-	free (charLine);
+  free (charLine);
 }
 
 void ConfigScanner::throwScanError(string message) {
-	std::cerr << message << std::endl;
+  std::cerr << message << std::endl;
 }
 
 Environment* ConfigScanner::getEnviro() {
-	return &enviro;
+  return &enviro;
 }
 
 string ConfigScanner::getConfigPath() {
-	return configPath;
+  return configPath;
 }
 
 long ConfigScanner::getSteps() {
-	return numOfSteps;
+  return numOfSteps;
 }
 
 string ConfigScanner::getOplsusaparPath() {
-	return oplsuaparPath;
+  return oplsuaparPath;
 }
 
 string ConfigScanner::getZmatrixPath() {
-	return zmatrixPath;
+  return zmatrixPath;
 }
 
 string ConfigScanner::getStatePath() {
-	return statePath;
+  return statePath;
 }
 
 string ConfigScanner::getStateOutputPath() {
-	return stateOutputPath;
+  return stateOutputPath;
 }
 
 string ConfigScanner::getPdbOutputPath() {
-	return pdbOutputPath;
+  return pdbOutputPath;
 }
 
 string ConfigScanner::getSimulationName() {
-	return simName;
+  return simName;
+}
+
+string ConfigScanner::getStrategy() {
+  return strategy;
 }

--- a/src/Metropolis/Utilities/FileUtilities.cpp
+++ b/src/Metropolis/Utilities/FileUtilities.cpp
@@ -15,149 +15,169 @@ using std::ifstream;
 
 #define DEFAULT_STEP_COUNT 100
 
-bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep, long* steps) {
-
-	if (box == NULL) {			// If box is null, print an error and return.
-		std::cerr << "Error: loadBoxData(): Box is NULL" << std::endl;
-		return false;
-	}
+bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep,
+                 long* steps) {
+  if (box == NULL) { // If box is null, print an error and return.
+    std::cerr << "Error: loadBoxData(): Box is NULL" << std::endl;
+    return false;
+  }
 
   Environment* enviro;
   vector<Molecule> moleculeVector;
+  SBScanner sb_scanner;
 
-	SBScanner sb_scanner;
-
-  if (simArgs.fileType == InputFile::Configuration) {	// Build from config/z-matrix.
-
-	  // Reading in config information from config file.
-		ConfigScanner config_scanner = ConfigScanner();
+  // Build from config/z-matrix.
+  if (simArgs.fileType == InputFile::Configuration) {
+    // Read in config information from config file.
+    ConfigScanner config_scanner = ConfigScanner();
     if (!config_scanner.readInConfig(simArgs.filePath)) {
-  		std::cerr << "Error: loadBoxData(): Could not read config file" << std::endl;
+      std::cerr << "Error: loadBoxData(): Could not read config file"
+                << std::endl;
       return false;
     }
-	simArgs.pdbOutputPath = config_scanner.getPdbOutputPath();
-	simArgs.stateOutputPath = config_scanner.getStateOutputPath();
-	if (!config_scanner.getSimulationName().empty() &&
-			simArgs.simulationName.empty()) {
-		simArgs.simulationName = config_scanner.getSimulationName();
-	}
+    simArgs.pdbOutputPath = config_scanner.getPdbOutputPath();
+    simArgs.stateOutputPath = config_scanner.getStateOutputPath();
+    if (!config_scanner.getSimulationName().empty() &&
+        simArgs.simulationName.empty()) {
+      simArgs.simulationName = config_scanner.getSimulationName();
+    }
 
-		// Getting bond and angle data from oplsaa.sb file.
-	  sb_scanner = SBScanner();
-		std::string sb_path = config_scanner.getOplsusaparPath();
-		std::size_t slash_index= sb_path.find_last_of('/');
-		sb_path = sb_path.substr(0, slash_index);
+    if (!config_scanner.getStrategy().empty() &&
+        simArgs.strategy == Strategy::Default) {
+      simArgs.strategy = Strategy::fromString(config_scanner.getStrategy());
+      if (simArgs.strategy == Strategy::Unknown) {
+        std::cerr << "Error: Unknown energy calculation strategy specified "
+                     "in config file"
+                  << std::endl;
+        return false;
+      }
+    }
 
-		if(!sb_scanner.readInSB(sb_path + "/oplsaa.sb")) {
-			std::cerr << "Error: loadBoxData(): Could not read OPLS SB file" << std::endl;
-			return false;
-		}
+    // Getting bond and angle data from oplsaa.sb file.
+    sb_scanner = SBScanner();
+    std::string sb_path = config_scanner.getOplsusaparPath();
+    std::size_t slash_index= sb_path.find_last_of('/');
+    sb_path = sb_path.substr(0, slash_index);
 
-		// Getting atom data from the oplsaa.par / oplsua.par files.
+    if(!sb_scanner.readInSB(sb_path + "/oplsaa.sb")) {
+      std::cerr << "Error: loadBoxData(): Could not read OPLS SB file"
+                << std::endl;
+      return false;
+    }
+
+    // Getting atom data from the oplsaa.par / oplsua.par files.
     OplsScanner opls_scanner = OplsScanner();
     if (!opls_scanner.readInOpls(config_scanner.getOplsusaparPath())) {
-    	std::cerr << "Error: loadBoxData(): Could not read OPLS file" << std::endl;
+      std::cerr << "Error: loadBoxData(): Could not read OPLS file"
+                << std::endl;
       return false;
     }
 
-		// Reading in molecule information from the z-matrix.
+    // Reading in molecule information from the z-matrix.
     ZmatrixScanner zmatrix_scanner = ZmatrixScanner();
-    if (!zmatrix_scanner.readInZmatrix(config_scanner.getZmatrixPath(), &opls_scanner)) {
-    	std::cerr << "Error: loadBoxData(): Could not read Z-Matrix file" << std::endl;
+    if (!zmatrix_scanner.readInZmatrix(config_scanner.getZmatrixPath(),
+                                       &opls_scanner)) {
+      std::cerr << "Error: loadBoxData(): Could not read Z-Matrix file"
+                << std::endl;
       return false;
     }
 
-		// Initialize moleculeVector, environment and steps.
+    // Initialize moleculeVector, environment and steps.
     moleculeVector = zmatrix_scanner.buildMolecule(0);
     enviro = config_scanner.getEnviro();
     *steps = config_scanner.getSteps();
     *startStep = 0;
 
-		// Verify that the # of molecules is consitent in z-matrix and config files.
-		if (moleculeVector.size() != enviro->primaryAtomIndexDefinitions) {
-
-			std::cerr << "Error: loadBoxData(): The number of molecules read "
-								<< "from the Z Matrix file (" << moleculeVector.size()
-	    					<< ") does not equal the number of primary index "
-								<< "definitions in the config file ("
-	    					<< enviro->primaryAtomIndexDefinitions << ")"
-								<< std::endl;
-            return false;
+    // Verify that the # of molecules is consitent in z-matrix and config
+    if (moleculeVector.size() != enviro->primaryAtomIndexDefinitions) {
+      std::cerr << "Error: loadBoxData(): The number of molecules read "
+                << "from the Z Matrix file (" << moleculeVector.size()
+                << ") does not equal the number of primary index "
+                << "definitions in the config file ("
+                << enviro->primaryAtomIndexDefinitions << ")"
+                << std::endl;
+      return false;
     }
 
-		// Instantiate the box's environment.
+    // Instantiate the box's environment.
     box->environment = new Environment(enviro);
 
-		// Build the box's data.
+    // Build the box's data.
     if (!buildBoxData(enviro, moleculeVector, box, sb_scanner)) {
-    	std::cerr << "Error: loadBoxData(): Could not build box data" << std::endl;
-      return false;
-    }
-
-  	return true;
-
-  } else if (simArgs.fileType == InputFile::State) {		// Build from state file.
-
-		// Instantiate a state scanner and read in the environment.
-		StateScanner state_scanner = StateScanner(simArgs.filePath);
-    enviro = state_scanner.readInEnvironment();
-
-		// Validate the environment
-    if (enviro == NULL) {
-    	std::cerr << "Error: Unable to read environment from State File" << std::endl;
-      return false;
-    }
-
-		// Get the molecule vector from the state scanner.
-		moleculeVector = state_scanner.readInMolecules();
-
-		// Validate the molecule vector.
-    if (moleculeVector.size() == 0) {
-    	std::cerr << "Error: Unable to read molecule data from State file" << std::endl;
-      return false;
-    }
-
-		// Instantiate steps / start step.
-    *steps = DEFAULT_STEP_COUNT;
-    *startStep = state_scanner.readInStepNumber();
-
-		// Validate start step.
-    if (*startStep < 0) {
-  		std::cerr << "Error: State file does not have a starting step number" << std::endl;
-      return false;
-  	}
-
-		// If environment is validated, set the box's environment.
-    box->environment = new Environment(enviro);
-
-		// Populate the box with data.
-    if (!fillBoxData(enviro, moleculeVector, box, sb_scanner)) {
-    	std::cerr << "Error: loadBoxData(): Could not build box data" << std::endl;
+      std::cerr << "Error: loadBoxData(): Could not build box data" << std::endl;
       return false;
     }
 
     return true;
   }
 
-	// If we are neither building from config/z-matrix or state file, print error.
+  // Build from state file.
+  if (simArgs.fileType == InputFile::State) {
+    // Instantiate a state scanner and read in the environment.
+    StateScanner state_scanner = StateScanner(simArgs.filePath);
+    enviro = state_scanner.readInEnvironment();
+
+    // Validate the environment
+    if (enviro == NULL) {
+      std::cerr << "Error: Unable to read environment from State File"
+                << std::endl;
+      return false;
+    }
+
+    // Get the molecule vector from the state scanner.
+    moleculeVector = state_scanner.readInMolecules();
+
+    // Validate the molecule vector.
+    if (moleculeVector.size() == 0) {
+      std::cerr << "Error: Unable to read molecule data from State file"
+                << std::endl;
+      return false;
+    }
+
+    // Instantiate steps / start step.
+    *steps = DEFAULT_STEP_COUNT;
+    *startStep = state_scanner.readInStepNumber();
+
+    // Validate start step.
+    if (*startStep < 0) {
+      std::cerr << "Error: State file does not have a starting step number"
+                << std::endl;
+      return false;
+    }
+
+    // If environment is validated, set the box's environment.
+    box->environment = new Environment(enviro);
+
+    // Populate the box with data.
+    if (!fillBoxData(enviro, moleculeVector, box, sb_scanner)) {
+      std::cerr << "Error: loadBoxData(): Could not build box data"
+                << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+
+  // If we are neither building from config/z-matrix or state file, print error.
   std::cout << "Error: Could not recognize input file type" << std::endl;
-	return false;
+  return false;
 }
 
 
-bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBScanner& sb_scanner) {
-
-	//if the vector of molecules has no contents, print an error and return.
-	if (!enviro || !box || molecVec.size() < 1) {
-  	std::cerr << "Error: fillBoxData(): Could not fill molecule data." << std::endl;
+bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box,
+                 SBScanner& sb_scanner) {
+  // If the vector of molecules has no contents, print an error and return
+  if (!enviro || !box || molecVec.size() < 1) {
+    std::cerr << "Error: fillBoxData(): Could not fill molecule data."
+              << std::endl;
     return false;
   }
 
-	// Holds the running number of atoms, bonds, angles, dihedrals, and hops.
+  // Holds the running number of atoms, bonds, angles, dihedrals, and hops.
   int count[5];
-  memset(count,0,sizeof(count));	// Instantiate count.
+  memset(count,0,sizeof(count));  // Instantiate count.
 
-	// Instantiate the box's relevant variables.
+  // Instantiate the box's relevant variables.
   box->moleculeCount = 0;
   box->atomCount = 0;
   box->bondCount = 0;
@@ -165,19 +185,19 @@ bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBSc
   box->dihedralCount = 0;
   box->hopCount = 0;
 
-	// For every molecule in the vector, increment the box's count for each
-	// sub-value accordingly.
+  // For every molecule in the vector, increment the box's count for each
+  // sub-value accordingly.
   for (int i = 0; i < molecVec.size(); ++i) {
-        Molecule mol = molecVec[i];
-        box->moleculeCount += 1;
-        box->atomCount += mol.numOfAtoms;
-        box->bondCount += mol.numOfBonds;
-        box->angleCount += mol.numOfAngles;
-        box->dihedralCount += mol.numOfDihedrals;
-        box->hopCount += mol.numOfHops;
+    Molecule mol = molecVec[i];
+    box->moleculeCount += 1;
+    box->atomCount += mol.numOfAtoms;
+    box->bondCount += mol.numOfBonds;
+    box->angleCount += mol.numOfAngles;
+    box->dihedralCount += mol.numOfDihedrals;
+    box->hopCount += mol.numOfHops;
   }
 
-	// Allocate space for the box's various structures.
+  // Allocate space for the box's various structures.
   box->molecules = (Molecule *) malloc(sizeof(Molecule) * box->moleculeCount);
   box->atoms     = (Atom *) malloc(sizeof(Atom) * box->atomCount);
   box->bonds     = (Bond *) malloc(sizeof(Bond) *  box->bondCount);
@@ -185,30 +205,30 @@ bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBSc
   box->dihedrals = (Dihedral *) malloc(sizeof(Dihedral) * box->dihedralCount);
   box->hops      = (Hop *) malloc(sizeof(Hop) * box->hopCount);
 
-	// Clear the space allocated for the box's structures.
-	// Why do we not clear box->molecules?
+  // Clear the space allocated for the box's structures.
+  // Why do we not clear box->molecules?
   memset(box->atoms, 0, sizeof(Atom) * box->atomCount);
   memset(box->bonds, 0, sizeof(Bond) * box->bondCount);
   memset(box->angles, 0, sizeof(Angle) * box->angleCount);
   memset(box->dihedrals, 0, sizeof(Dihedral) * box->dihedralCount);
   memset(box->hops, 0, sizeof(Hop) * box->hopCount);
 
-	std::vector<Bond> bondVector;	// bondVector will hold a list of bonds.
-	// These will be used to get the common atom in every angle.
+  std::vector<Bond> bondVector; // bondVector will hold a list of bonds.
+  // These will be used to get the common atom in every angle.
 
-	//Copy data from vector to molecule
+  //Copy data from vector to molecule
   for (int j = 0; j < molecVec.size(); j++) {
     Molecule molec1 = molecVec[j];
 
-		// Point to memory allocated to atoms, bonds, etc in the box with the
-		// atoms, bonds, etc. arrays in each molecule.
+    // Point to memory allocated to atoms, bonds, etc in the box with the
+    // atoms, bonds, etc. arrays in each molecule.
     box->molecules[j].atoms = (Atom *) (box->atoms + count[0]);
     box->molecules[j].bonds = (Bond *) (box->bonds + count[1]);
     box->molecules[j].angles = (Angle *) (box->angles + count[2]);
     box->molecules[j].dihedrals = (Dihedral *) (box->dihedrals + count[3]);
     box->molecules[j].hops = (Hop *) (box->hops + count[4]);
 
-		// Copy over constants from each element in the molecule vector.
+    // Copy over constants from each element in the molecule vector.
     box->molecules[j].id = molec1.id;
     box->molecules[j].type = molec1.type;
     box->molecules[j].numOfAtoms = molec1.numOfAtoms;
@@ -217,7 +237,7 @@ bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBSc
     box->molecules[j].numOfAngles = molec1.numOfAngles;
     box->molecules[j].numOfHops = molec1.numOfHops;
 
-		// Increment the offset to point data to.
+    // Increment the offset to point data to.
     count[0] += molec1.numOfAtoms;
     count[1] += molec1.numOfBonds;
     count[2] += molec1.numOfAngles;
@@ -226,30 +246,30 @@ bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBSc
 
     // Copy over atoms from the molecule vector.
     for (int k = 0; k < molec1.numOfAtoms; k++) {
-    	box->molecules[j].atoms[k] = molec1.atoms[k];
+      box->molecules[j].atoms[k] = molec1.atoms[k];
     }
 
     // Copy over bonds from the molecule vector.
     for (int k = 0; k < molec1.numOfBonds; k++) {
-			box->molecules[j].bonds[k] = molec1.bonds[k];
+      box->molecules[j].bonds[k] = molec1.bonds[k];
 
-			// Add the bond to bondVector
-			bondVector.push_back(molec1.bonds[k]);
+      // Add the bond to bondVector
+      bondVector.push_back(molec1.bonds[k]);
     }
 
     // Copy over angles from the molecule vector.
     for (int k = 0; k < molec1.numOfAngles; k++) {
-    	box->molecules[j].angles[k] = molec1.angles[k];
+      box->molecules[j].angles[k] = molec1.angles[k];
     }
 
     // Copy over dihedrals from the molecule vector.
     for(int k = 0; k < molec1.numOfDihedrals; k++) {
-    	box->molecules[j].dihedrals[k] = molec1.dihedrals[k];
+      box->molecules[j].dihedrals[k] = molec1.dihedrals[k];
     }
 
     // Copy over hops from the molecule vector.
     for(int k = 0; k < molec1.numOfHops; k++) {
-    	box->molecules[j].hops[k] = molec1.hops[k];
+      box->molecules[j].hops[k] = molec1.hops[k];
     }
 
   } // Repeat for every molecule in the vector.
@@ -258,106 +278,108 @@ bool fillBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBSc
   return true;
 }
 
-bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBScanner& sb_scanner) {
+bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box,
+                  SBScanner& sb_scanner) {
 
-	// Convert molecule vectors into an array
+  // Convert molecule vectors into an array
   //int moleculeIndex = 0;
   //int atomCount = 0;
 
-	// If the vector of molecules has no contents, print an error and return.
+  // If the vector of molecules has no contents, print an error and return.
   if (!enviro || !box || molecVec.size() < 1) {
-    std::cerr << "Error: buildBoxData(): Could not load molecule data." << std::endl;
+    std::cerr << "Error: buildBoxData(): Could not load molecule data."
+              << std::endl;
     return false;
   }
 
-	// Make nunOfMolecules divisible by the size of the molecule vector.
+  // Make nunOfMolecules divisible by the size of the molecule vector.
   int molecMod = enviro->numOfMolecules % molecVec.size();
-  if (molecMod != 0)	{
-  	enviro->numOfMolecules += molecVec.size() - molecMod;
+  if (molecMod != 0)  {
+    enviro->numOfMolecules += molecVec.size() - molecMod;
   }
 
-	// Allocate memory for the molecues in the box.
+  // Allocate memory for the molecues in the box.
   box->moleculeCount = enviro->numOfMolecules;
   box->molecules = (Molecule *) malloc(sizeof(Molecule) * box->moleculeCount);
 
-	// If there aren't any molecules, return an error.
+  // If there aren't any molecules, return an error.
   if(box->moleculeCount < 1 || molecVec.size() < 1) {
-  	std::cerr << "The simulation environment should have at least 1 "
-							<< "molecule. (The current count? " << box->moleculeCount
-							<<")." << std::endl;
-  	return false;
+    std::cerr << "The simulation environment should have at least 1 "
+              << "molecule. (The current count? " << box->moleculeCount
+              <<")." << std::endl;
+    return false;
   }
 
 
-	int molecDiv = enviro->numOfMolecules / molecVec.size();
+  int molecDiv = enviro->numOfMolecules / molecVec.size();
   int molecTypeNum = molecVec.size();
 
-	// Holds the running number of atoms, bonds, angles, dihedrals, and hops.
+  // Holds the running number of atoms, bonds, angles, dihedrals, and hops.
   int count[5];
-	memset(count,0,sizeof(count)); // Instantiate count.
+  memset(count,0,sizeof(count)); // Instantiate count.
 
-	// Allocate memory for tables.
-	Table* tables = new Table[molecVec.size()];
-	int currentAtomCount = 0;
+  // Allocate memory for tables.
+  Table* tables = new Table[molecVec.size()];
+  int currentAtomCount = 0;
 
-	//Copy data from vector to molecule
+  //Copy data from vector to molecule
   for (int j = 0; j < molecVec.size(); j++) {
-  	Molecule molec1 = molecVec[j];
+    Molecule molec1 = molecVec[j];
 
-		// Count the number of atoms, bonds, etc.
-  	count[0] += molec1.numOfAtoms;
-  	count[1] += molec1.numOfBonds;
-  	count[2] += molec1.numOfAngles;
-  	count[3] += molec1.numOfDihedrals;
-  	count[4] += molec1.numOfHops;
+    // Count the number of atoms, bonds, etc.
+    count[0] += molec1.numOfAtoms;
+    count[1] += molec1.numOfBonds;
+    count[2] += molec1.numOfAngles;
+    count[3] += molec1.numOfDihedrals;
+    count[4] += molec1.numOfHops;
 
-		// Begin copying hops.
-  	Hop *myHop = molec1.hops;
-  	int **table;
+    // Begin copying hops.
+    Hop *myHop = molec1.hops;
+    int **table;
 
-		// Allocate memory to tables.
-		table = new int*[molec1.numOfAtoms];
-  	for(int k = 0; k < molec1.numOfAtoms;k++) {
-  		table[k] = new int[molec1.numOfAtoms];
-		}
+    // Allocate memory to tables.
+    table = new int*[molec1.numOfAtoms];
+    for(int k = 0; k < molec1.numOfAtoms;k++) {
+      table[k] = new int[molec1.numOfAtoms];
+    }
 
-		// Instantiate table to 0.
-  	for(int test = 0; test< molec1.numOfAtoms;test++) {
-  		for(int test1 = 0; test1 < molec1.numOfAtoms; test1++) {
-  				table[test][test1] = 0;
-  		}
-		}
+    // Instantiate table to 0.
+    for(int test = 0; test< molec1.numOfAtoms;test++) {
+      for(int test1 = 0; test1 < molec1.numOfAtoms; test1++) {
+          table[test][test1] = 0;
+      }
+    }
 
-		// Fill table with hops.
-		for(int k2 = 0; k2<molec1.numOfHops;k2++) {
-			int atom1 = myHop->atom1;
-			int atom2 = myHop->atom2;
-			table[atom1-currentAtomCount][atom2-currentAtomCount] = myHop->hop;
-			table[atom2-currentAtomCount][atom1-currentAtomCount] = myHop->hop;
-			myHop++;
-		}
+    // Fill table with hops.
+    for(int k2 = 0; k2<molec1.numOfHops;k2++) {
+      int atom1 = myHop->atom1;
+      int atom2 = myHop->atom2;
+      table[atom1-currentAtomCount][atom2-currentAtomCount] = myHop->hop;
+      table[atom2-currentAtomCount][atom1-currentAtomCount] = myHop->hop;
+      myHop++;
+    }
 
-		// Put the table in tables.
-	  tables[j] = Table(table);
-		// Increase the number atoms in the molecule.
-	  currentAtomCount += molec1.numOfAtoms;
-	}
+    // Put the table in tables.
+    tables[j] = Table(table);
+    // Increase the number atoms in the molecule.
+    currentAtomCount += molec1.numOfAtoms;
+  }
 
-	// Fill box variables.
+  // Fill box variables.
   box->atomCount = molecDiv * count[0];
   box->bondCount = molecDiv * count[1];
   box->angleCount = molecDiv * count[2];
   box->dihedralCount = molecDiv * count[3];
   box->hopCount = molecDiv * count[4];
 
-	// Allocate memory to box.
-  box->atoms 	   = (Atom *) malloc(sizeof(Atom) * box->atomCount);
+  // Allocate memory to box.
+  box->atoms     = (Atom *) malloc(sizeof(Atom) * box->atomCount);
   box->bonds     = (Bond *) malloc(sizeof(Bond) * box->bondCount);
   box->angles    = (Angle *) malloc(sizeof(Angle) * box->angleCount);
   box->dihedrals = (Dihedral *) malloc(sizeof(Dihedral) * box->dihedralCount);
   box->hops      = (Hop *) malloc(sizeof(Hop) * box->hopCount);
 
-	// Clear memory in the box.
+  // Clear memory in the box.
   memset(box->atoms, 0, sizeof(Atom) * box->atomCount);
   memset(box->bonds, 0, sizeof(Bond) * box->bondCount);
   memset(box->angles, 0, sizeof(Angle) * box->angleCount);
@@ -367,23 +389,23 @@ bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBS
   //Clear count.
   memset(count, 0, sizeof(count));
 
-	std::vector<Bond> bondVector;	// bondVector will hold a list of bonds.
-	// These will be used to get the common atom in every angle.
+  std::vector<Bond> bondVector; // bondVector will hold a list of bonds.
+  // These will be used to get the common atom in every angle.
 
-	//Copy data from vector to molecule.
- 	for(int j = 0; j < molecVec.size(); j++) {
+  //Copy data from vector to molecule.
+  for(int j = 0; j < molecVec.size(); j++) {
 
     Molecule molec1 = molecVec[j]; // Get the molecule from the molecule vector.
 
-		// Point to memory allocated to atoms, bonds, etc in the box with the
-		// atoms, bonds, etc. arrays in each molecule.
+    // Point to memory allocated to atoms, bonds, etc in the box with the
+    // atoms, bonds, etc. arrays in each molecule.
     box->molecules[j].atoms = (Atom *) (box->atoms + count[0]);
     box->molecules[j].bonds = (Bond *) (box->bonds + count[1]);
     box->molecules[j].angles = (Angle *) (box->angles + count[2]);
     box->molecules[j].dihedrals = (Dihedral *) (box->dihedrals + count[3]);
     box->molecules[j].hops = (Hop *) (box->hops + count[4]);
 
-		// Copy over molecule values from the molecule in the vector.
+    // Copy over molecule values from the molecule in the vector.
     box->molecules[j].id = molec1.id;
     box->molecules[j].type = molec1.type;
     box->molecules[j].numOfAtoms = molec1.numOfAtoms;
@@ -392,8 +414,8 @@ bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBS
     box->molecules[j].numOfAngles = molec1.numOfAngles;
     box->molecules[j].numOfHops = molec1.numOfHops;
 
-		// Increment the count of atoms, bonds, etc.
-		// This will set the offset for the next pointer assignment.
+    // Increment the count of atoms, bonds, etc.
+    // This will set the offset for the next pointer assignment.
     count[0] += molec1.numOfAtoms;
     count[1] += molec1.numOfBonds;
     count[2] += molec1.numOfAngles;
@@ -402,99 +424,104 @@ bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBS
 
     // Copy atoms from the molecule vector.
     for (int k = 0; k < molec1.numOfAtoms; k++) {
-    	box->molecules[j].atoms[k] = molec1.atoms[k];
+      box->molecules[j].atoms[k] = molec1.atoms[k];
     }
-
-
 
     // Copy bonds from the molecule vector.
     for (int k = 0; k < molec1.numOfBonds; k++) {
-			box->molecules[j].bonds[k] = molec1.bonds[k];
+      box->molecules[j].bonds[k] = molec1.bonds[k];
 
-			// Add the bond to bondVector
-			bondVector.push_back(molec1.bonds[k]);
+      // Add the bond to bondVector
+      bondVector.push_back(molec1.bonds[k]);
     }
 
     // Copy angles from the molecule vector.
     for (int k = 0; k < molec1.numOfAngles; k++) {
-  		box->molecules[j].angles[k] = molec1.angles[k];
-			int a1Idx = molec1.angles[k].atom1;
-			int a2Idx = molec1.angles[k].atom2;
-			box->molecules[j].angles[k].commonAtom = getCommonAtom(bondVector, a1Idx, a2Idx);
+      box->molecules[j].angles[k] = molec1.angles[k];
+      int a1Idx = molec1.angles[k].atom1;
+      int a2Idx = molec1.angles[k].atom2;
+      box->molecules[j].angles[k].commonAtom = getCommonAtom(bondVector,
+                                                             a1Idx, a2Idx);
     }
 
 
     // Copy dihedrals from the molecule vector.
     for (int k = 0; k < molec1.numOfDihedrals; k++) {
-    	box->molecules[j].dihedrals[k] = molec1.dihedrals[k];
+      box->molecules[j].dihedrals[k] = molec1.dihedrals[k];
     }
 
     // Copy hops from the molecule vector.
     for (int k = 0; k < molec1.numOfHops; k++) {
-    	box->molecules[j].hops[k] = molec1.hops[k];
+      box->molecules[j].hops[k] = molec1.hops[k];
     }
 
-	} // Repeat for every molecule in the molecule vector.
+  } // Repeat for every molecule in the molecule vector.
 
-	// Repeat for each copy of every molecule in the vector.
+  // Repeat for each copy of every molecule in the vector.
   for (int m = 1; m < molecDiv; m++) {
-		// Copy the molecule into the corresponding spot in the box.
-  	int offset = m * molecTypeNum;
-    memcpy(&(box->molecules[offset]), box->molecules, sizeof(Molecule) * molecTypeNum);
+    // Copy the molecule into the corresponding spot in the box.
+    int offset = m * molecTypeNum;
+    memcpy(&(box->molecules[offset]), box->molecules,
+           sizeof(Molecule) * molecTypeNum);
 
-		// Copy atoms, bonds, etc. for each molecule.
-	  for (int n = 0; n < molecTypeNum; n++) {
-    	box->molecules[offset+n].id=offset+n;
+    // Copy atoms, bonds, etc. for each molecule.
+    for (int n = 0; n < molecTypeNum; n++) {
+      box->molecules[offset+n].id=offset+n;
       box->molecules[offset+n].atoms = box->molecules[n].atoms + count[0] * m;
-      box->molecules[offset+n].bonds =  box->molecules[n].bonds + count[1] * m;
-      box->molecules[offset+n].angles =  box->molecules[n].angles + count[2] * m;
-      box->molecules[offset+n].dihedrals =  box->molecules[n].dihedrals + count[3] * m;
+      box->molecules[offset+n].bonds = box->molecules[n].bonds + count[1] * m;
+      box->molecules[offset+n].angles = box->molecules[n].angles 
+        + count[2] * m;
+      box->molecules[offset+n].dihedrals = box->molecules[n].dihedrals
+        + count[3] * m;
       box->molecules[offset+n].hops =  box->molecules[n].hops + count[4] * m;
     }
 
-		memcpy(&(box->atoms[m * count[0]]), box->atoms, sizeof(Atom) * count[0]);
-	  memcpy(&(box->bonds[m * count[1]]), box->bonds, sizeof(Bond) * count[1]);
-	  memcpy(&(box->angles[m * count[2]]), box->angles, sizeof(Angle) * count[2]);
-	  memcpy(&(box->dihedrals[m * count[3]]), box->dihedrals, sizeof(Dihedral) * count[3]);
-	  memcpy(&(box->hops[m * count[4]]), box->hops, sizeof(Hop) * count[4]);
+    memcpy(&(box->atoms[m * count[0]]), box->atoms, sizeof(Atom) * count[0]);
+    memcpy(&(box->bonds[m * count[1]]), box->bonds, sizeof(Bond) * count[1]);
+    memcpy(&(box->angles[m * count[2]]),
+           box->angles, sizeof(Angle) * count[2]);
+    memcpy(&(box->dihedrals[m * count[3]]), box->dihedrals,
+           sizeof(Dihedral) * count[3]);
+    memcpy(&(box->hops[m * count[4]]), box->hops, sizeof(Hop) * count[4]);
 
-		// Copy atoms for each molecule.
-    for (int k = 0; k < count[0]; k++)	{
-    	box->atoms[m * count[0] + k].id = m * count[0] + k;
+    // Copy atoms for each molecule.
+    for (int k = 0; k < count[0]; k++)  {
+      box->atoms[m * count[0] + k].id = m * count[0] + k;
     }
 
-		// Copy bonds for each molecule.
+    // Copy bonds for each molecule.
     for (int k = 0; k < count[1]; k++) {
-    	box->bonds[m * count[1] + k].atom1 += m * count[0];
+      box->bonds[m * count[1] + k].atom1 += m * count[0];
       box->bonds[m * count[1] + k].atom2 += m * count[0];
     }
 
-		// Copy angles for each molecule.
+    // Copy angles for each molecule.
     for(int k = 0; k < count[2]; k++) {
-    	box->angles[m * count[2] + k].atom1 += m * count[0];
+      box->angles[m * count[2] + k].atom1 += m * count[0];
       box->angles[m * count[2] + k].atom2 += m * count[0];
-			box->angles[m * count[2] + k].commonAtom += m * count[0];
+      box->angles[m * count[2] + k].commonAtom += m * count[0];
     }
 
-		// Copy dihedrals for each molecule.
+    // Copy dihedrals for each molecule.
     for(int k = 0; k < count[3]; k++) {
-    	box->dihedrals[m * count[3] + k].atom1 += m * count[0];
+      box->dihedrals[m * count[3] + k].atom1 += m * count[0];
       box->dihedrals[m * count[3] + k].atom2 += m * count[0];
-  	}
+    }
 
-		// Copy hops for each molecule.
+    // Copy hops for each molecule.
     for(int k = 0; k < count[4]; k++) {
-    	box->hops[m * count[4] + k].atom1 += m * count[0];
+      box->hops[m * count[4] + k].atom1 += m * count[0];
       box->hops[m * count[4] + k].atom2 += m * count[0];
     }
 
-  }	// Repeat for every molecule.
+  } // Repeat for every molecule.
 
   enviro->numOfAtoms = count[0] * molecDiv;
 
-	//generate fcc lattice box
+  //generate fcc lattice box
   if (!generatefccBox(box)) {
-  	std::cerr << "Error: buildBoxData(): Could not generate FCC box" << std::endl;
+    std::cerr << "Error: buildBoxData(): Could not generate FCC box"
+              << std::endl;
     return false;
   }
 
@@ -502,45 +529,46 @@ bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBS
 }
 
 bool generatefccBox(Box* box) {
-	// Return an error if the box is missing an environment or molecules.
-	if (box->environment == NULL || box->molecules == NULL) {
-		std::cerr << "Error: generatefccBox(): Box environment or molecules array NULL" << std::endl;
-		return false;
-	}
-
-	Real cells, dcells, cellL, halfcellL;
-	Environment* enviro = box->environment;
-	Molecule* molecules = box->molecules;
-
-	//Determine the number of unit cells in each coordinate direction
-	dcells = pow(0.25 * (Real) enviro->numOfMolecules, 1.0/3.0);
-	cells = (int)(dcells + 0.5);
-
-	//Check if numOfMolecules is a non-fcc number of molecules
-	//and increase the number of cells if necessary
-	while((4 * cells * cells * cells) < enviro->numOfMolecules) {
-		cells++;
+  // Return an error if the box is missing an environment or molecules.
+  if (box->environment == NULL || box->molecules == NULL) {
+    std::cerr << "Error: generatefccBox(): Box environment or molecules "
+                 "array NULL" << std::endl;
+    return false;
   }
 
-	//Determine length of unit cell
-	cellL = enviro->x / (Real) cells;
-	halfcellL = 0.5 * cellL;
+  Real cells, dcells, cellL, halfcellL;
+  Environment* enviro = box->environment;
+  Molecule* molecules = box->molecules;
 
-	//Construct the unit cell
-	for (int j = 0; j < molecules[0].numOfAtoms; j++) {
+  // Determine the number of unit cells in each coordinate direction
+  dcells = pow(0.25 * (Real) enviro->numOfMolecules, 1.0/3.0);
+  cells = (int)(dcells + 0.5);
+
+  // Check if numOfMolecules is a non-fcc number of molecules and increase
+  // the number of cells if necessary
+  while((4 * cells * cells * cells) < enviro->numOfMolecules) {
+    cells++;
+  }
+
+  //Determine length of unit cell
+  cellL = enviro->x / (Real) cells;
+  halfcellL = 0.5 * cellL;
+
+  //Construct the unit cell
+  for (int j = 0; j < molecules[0].numOfAtoms; j++) {
     molecules[0].atoms[j].x += 0.0;
     molecules[0].atoms[j].y += 0.0;
     molecules[0].atoms[j].z += 0.0;
-	}
+  }
 
-	for (int j = 0; j < molecules[1].numOfAtoms; j++) {
+  for (int j = 0; j < molecules[1].numOfAtoms; j++) {
     molecules[1].atoms[j].x += halfcellL;
     molecules[1].atoms[j].y += halfcellL;
     molecules[1].atoms[j].z += 0.0;
   }
 
   for (int j = 0; j < molecules[2].numOfAtoms; j++) {
-  	molecules[2].atoms[j].x += 0.0;
+    molecules[2].atoms[j].x += 0.0;
     molecules[2].atoms[j].y += halfcellL;
     molecules[2].atoms[j].z += halfcellL;
   }
@@ -551,47 +579,47 @@ bool generatefccBox(Box* box) {
     molecules[3].atoms[j].z += halfcellL;
   }
 
-	//Init all other molecules to initial coordinates
-	//Build the lattice from the unit cell by repeatedly translating
-	//the four vectors of the unit cell through a distance cellL in
-	//the x, y, and z directions
-	for(int i = 4; i < enviro->numOfMolecules; i++) {
-		for (int j = 0; j < molecules[i].numOfAtoms; j++) {
-			molecules[i].atoms[j].x += 0.0;
-    	molecules[i].atoms[j].y += 0.0;
-   	 	molecules[i].atoms[j].z += 0.0;
-   	}
-	}
+  // Init all other molecules to initial coordinates
+  // Build the lattice from the unit cell by repeatedly translating
+  // the four vectors of the unit cell through a distance cellL in
+  // the x, y, and z directions
+  for(int i = 4; i < enviro->numOfMolecules; i++) {
+    for (int j = 0; j < molecules[i].numOfAtoms; j++) {
+      molecules[i].atoms[j].x += 0.0;
+      molecules[i].atoms[j].y += 0.0;
+      molecules[i].atoms[j].z += 0.0;
+    }
+  }
 
-	int offset = 0;
-	for (int z = 1; z <= cells; z++) {
-		for (int y = 1; y <= cells; y++) {
-			for (int x = 1; x <= cells; x++) {
-				for (int a = 0; a < 4; a++) {
-					int i = a + offset;
-					if (i < enviro->numOfMolecules) {
-						for (int j = 0; j < molecules[i].numOfAtoms; j++) {
-							molecules[i].atoms[j].x = molecules[a].atoms[j].x + cellL * (x-1);
-							molecules[i].atoms[j].y = molecules[a].atoms[j].y + cellL * (y-1);
-							molecules[i].atoms[j].z = molecules[a].atoms[j].z + cellL * (z-1);
-						}
-					}
-				}
-				offset += 4;
-			}
-		}
-	}
+  int offset = 0;
+  for (int z = 1; z <= cells; z++) {
+    for (int y = 1; y <= cells; y++) {
+      for (int x = 1; x <= cells; x++) {
+        for (int a = 0; a < 4; a++) {
+          int i = a + offset;
+          if (i < enviro->numOfMolecules) {
+            for (int j = 0; j < molecules[i].numOfAtoms; j++) {
+              molecules[i].atoms[j].x = molecules[a].atoms[j].x + cellL * (x-1);
+              molecules[i].atoms[j].y = molecules[a].atoms[j].y + cellL * (y-1);
+              molecules[i].atoms[j].z = molecules[a].atoms[j].z + cellL * (z-1);
+            }
+          }
+        }
+        offset += 4;
+      }
+    }
+  }
 
-	//Shift center of box to the origin
-	for (int i = 0; i < enviro->numOfMolecules; i++) {
-		for (int j = 0; j < molecules[i].numOfAtoms; j++) {
-			molecules[i].atoms[j].x -= halfcellL;
-			molecules[i].atoms[j].y -= halfcellL;
-			molecules[i].atoms[j].z -= halfcellL;
-		}
-	}
+  //Shift center of box to the origin
+  for (int i = 0; i < enviro->numOfMolecules; i++) {
+    for (int j = 0; j < molecules[i].numOfAtoms; j++) {
+      molecules[i].atoms[j].x -= halfcellL;
+      molecules[i].atoms[j].y -= halfcellL;
+      molecules[i].atoms[j].z -= halfcellL;
+    }
+  }
 
-	return true;
+  return true;
 }
 
 // ============================================================================
@@ -600,17 +628,17 @@ bool generatefccBox(Box* box) {
 
 void writeToLog(string text,int stamp) {
   string filename = "OutputLog";
-	ofstream logFile;
-	logFile.open(filename.c_str(),ios::out|ios::app);
+  ofstream logFile;
+  logFile.open(filename.c_str(),ios::out|ios::app);
 
-	string hash ="";
-	time_t current_time;
+  string hash ="";
+  time_t current_time;
   struct tm * time_info;
   char timeString[9];  // space for "HH:MM:SS\0"
 
-	switch(stamp) {
-  	case START:
-    	//The start of a new simulation
+  switch(stamp) {
+    case START:
+      //The start of a new simulation
       logFile << "\n\n\n\n\n\n" << endl;
       logFile << "======================================================================"<<endl;
       logFile << "                       Starting Simulation: ";
@@ -620,7 +648,7 @@ void writeToLog(string text,int stamp) {
       logFile << timeString << endl;
       logFile << "----------------------------------------------------------------------"<<endl;
       break;
-		case END:
+    case END:
       //The end of a running simulation
       logFile << "----------------------------------------------------------------------"<<endl;
       logFile << "                       Ending Simulation: ";
@@ -645,19 +673,19 @@ void writeToLog(string text,int stamp) {
     default:
       logFile << "";
       break;
-	 }
-	 logFile << text << endl;
-	 logFile.close();
+   }
+   logFile << text << endl;
+   logFile.close();
 }
 
 void writeToLog(stringstream& ss, int stamp) {
-	writeToLog(ss.str(),stamp);
-	ss.str(""); // clears the string steam...
-	ss.clear();
+  writeToLog(ss.str(),stamp);
+  ss.str(""); // clears the string steam...
+  ss.clear();
 }
 
 std::string& rtrim(std::string& s) {
-	s.erase(s.find_last_not_of(TRIMMED_CHARS) + 1);
+  s.erase(s.find_last_not_of(TRIMMED_CHARS) + 1);
   return s;
 }
 

--- a/src/Metropolis/Utilities/FileUtilities.h
+++ b/src/Metropolis/Utilities/FileUtilities.h
@@ -23,686 +23,682 @@
 #define COMMENT_DELIM ';'
 
 class SBScanner {
-
-	private:
-
-		/**
-		 * Double map from one atom to another atom to data about the bond between the two atoms.
-		 */
-		map<string, map<string, BondData> > bondDataMap;
-
-		/**
-		 * Triple map from one atom to another atom to a third atom about the angle formed by those three atoms.
-		 */
-		map<string, map<string, map<string, AngleData> > > angleDataMap;
-
-		/**
-		 * Contains the path to the oplsaa.sb file.
-		 */
-		string fileName;
-
-		/**
-		 * Given a line of input that specifies the data pertaining to a bond, stores the data in the bondDataMap.
-		 * @param line A line of data from the OPLSAA.sb file.
-		 */
-		void processBond(string line);
-
-		/**
-		 * Given a line of input that specifies the data pertaining to an angle, stores the data in the angleDataMap.
-		 * @param line A line of data from the OPLSAA.sb file.
-		 */
-		void processAngle(string line);
-
-		/**
-		 * Given a line of input, stores the data in the pertinent map.
-		 * @param line A line of data from the OPLSAA.sb file.
-		 */
-		void processLine(string line);
-
-	public:
-
-		/**
-		 * Constructor for SBScanner;
-		 */
-		SBScanner();
-
-		/**
-		 * Destructor for SBScanner;
-		 */
-		~SBScanner();
-
-		/**
-		 * Reads in OPLS.sb and stores the bond and angle data.
-		 * @param fileName The path and name of the file to read from.
-		 * @return - success code
-		 * 			 0: successful
-		 *		     1: error
-		 */
-		bool readInSB(string filename);
-
-		/**
-		 * Given a pair of atoms, returns the kBond between them.
-		 * @param atom1 One of the atoms in the bond.
-		 * @param atom2 The other atom in the bond.
-		 * @return The force constant of the bond.
-		 */
-		Real getKBond(string atom1, string atom2);
-
-		/**
-		 * Given a pair of atoms, returns the eqBondDist between them.
-		 * @param atom1 One of the atoms in the bond.
-		 * @param atom2 The other atom in the bond.
-		 * @return The equilibrium bond distance.
-		 */
-		Real getEqBondDist(string atom1, string atom2);
-
-		/**
-		 * Given three atoms, returns the kAngle of the angle that they form.
-		 * @param endpoint1 The atom at one end of the angle.
-		 * @param middleAtom The atom in the middle of the angle.
-		 * @param endpoint2 The atom at the other end of the angle.
-		 * @return The force constant of the angle.
-		 */
-		Real getKAngle(string endpoint1, string middleAtom, string endpoint2);
-
-		/**
-		 * Given three atoms, returns the eqAngle of the angle that they form.
-		 * @param endpoint1 The atom at one end of the angle.
-		 * @param middleAtom The atom in the middle of the angle.
-		 * @param endpoint2 The atom at the other end of the angle.
-		 * @return The equilibrium angle formed by the three atoms (in degrees).
-		 */
-		Real getEqAngle(string endpoint1, string middleAtom, string endpoint2);
-
-};
-
-class ConfigScanner
-{
-    private:
-		/**
-		 * The name of the simulation being run.
-		 */
-		string simName;
-        /**
-          The environment used in the simulation.
-        */
-        Environment enviro;
-        /**
-          The path to the configuration file to be read.
-        */
-        string configPath;
-        /**
-          The number of step to run the simulation.
-        */
-        long numOfSteps;
-        /**
-          The path to the opls file.
-        */
-        string oplsuaparPath;
-        /**
-          The path to the Z-matrix file to be used in the simulation.
-        */
-        string zmatrixPath;
-        /**
-          The path to the state file to be used.
-        */
-        string statePath;
-        /**
-          The path to write the state output files.
-        */
-        string stateOutputPath;
-        /**
-          The path where to write the pdb output files.
-        */
-        string pdbOutputPath;
-        /**
-          The nonbonded cutoff distance.
-        */
-        long cutoff;
-
-        bool isSafeToContinue; //used to help with logic flow during detection of Zmatrix and State file paths in file
-        bool useStatefileSetup; //if true, always try the state file for pre-sim setup; else, try ZMatrix
-        bool useZMatrixSetup; //if set to true, use the ZMatrix file unless state file is available
-
-      	void throwScanError(string message);
-      	void parsePrimaryIndexDefinitions(string definitions);
-
-    public:
-        /// Default constructor that initializes the scanner to default
-        /// values but does not read in any files yet.
-        ConfigScanner();
-
-        /**
-          Reads in the config file located at config path
-          given in the constructor.
-        */
-        bool readInConfig(string configpath);
-
-        /**
-          @return - returns the environment variable in this Config_Scan
-        */
-        Environment* getEnviro();
-
-        /**
-          @return - returns the path to the configuration file.
-        */
-        string getConfigPath();
-
-        /**
-          @return getSteps - returns the number of steps to run the simulation.
-        */
-        long getSteps();
-
-        /**
-          @return - returns the path to the opls file for the simulation.
-        */
-        string getOplsusaparPath();
-
-        /**
-          @return - returns the path to the z-matrix file to be used in the
-          simulation
-        */
-        string getZmatrixPath();
-
-        /**
-          @return - returns the path to the state input file for the simulation.
-        */
-        string getStatePath();
-
-        /**
-          @return - returns the path to the state output file for the simulation.
-        */
-        string getStateOutputPath();
-
-        /**
-          @return - returns the path to the pdb output file(s) for the simulation.
-        */
-        string getPdbOutputPath();
-		
-		/**
-		 * @return - returns the simulation name
-		 */
-		string getSimulationName();
-
-        /**
-          @return getSteps - returns the nonbonded cutoff in the simulation.
-        */
-        long getcutoff();
-
-        /**
-          @return - returns the random seed used in the simulation.
-        */
-        unsigned int getrandomseed() {return enviro.randomseed;}
-
-        /**
-        	@return - returns whether or not we should use the state file for setup, with preference over the zmatrix file
-        */
-        bool doSetupFromStateFile() {return useStatefileSetup;}
-
-    		/**
-    			@return - return whether or not we should use the ZMatrix file for setup, in the event the state file isn't found
-    		*/
-    		bool doSetupFromZMatrixFile() {return useZMatrixSetup;}
-
-
-};
-
-
-class OplsScanner
-{
-   private:
-   /**
-     HashTable that holds all opls references
+ private:
+  /**
+   * Double map from one atom to another atom to data about the bond between
+   * the two atoms.
    */
-    map<string,Atom> oplsTable;
-	/**
-        HashTable that holds all the Fourier Coefficents
-		  stored
-    */
-    map<string,Fourier> fourierTable;
-    /**
-      the path to the OPLS file.
-    */
-    string fileName;
-	 /**
-     Vector used to keep track of errors when lines in
-	  the OPLS file that don't match the correct format.
-    */
-	 vector<int> errLines;
-	 /**
-      Vector used to keep track of errors when the hashes in
-		the OPLS file that exist more than once.
-    */
-	 vector<string> errHashes;
-	  /**
-      Vector used to keep track of errors when the hashes in the fourier coefficent
-		section of the OPLS file that exist more than once.
-    */
-	 vector<string> errHashesFourier;
-   public:
-   /**
-        Constrctor for the OplsScanner object.
-        @param fileName - the path to the OPLS file
-     */
-    OplsScanner(); // constructor
-    ~OplsScanner();
+  map<string, map<string, BondData> > bondDataMap;
 
-		/**
-		Scans in the opls File calls sub-function addLineToTable
-		@param filename - the name/path of the opls file
-        @return - success code
-                  0: successful
-                  1: error
-		*/
-      bool readInOpls(string filename);
+  /**
+   * Triple map from one atom to another atom to a third atom about the angle
+   * formed by those three atoms.
+   */
+  map<string, map<string, map<string, AngleData> > > angleDataMap;
 
-		/**
-		Parses out a line from the opls file and gets (sigma, epsilon, charge)
-		adds an entry to the map at the hash number position,
-		calls sub-function checkFormat()
-		@param line - a line from the opls file
-		@param numOflines - number of lines previously read in, used for error output
-		*/
-      void addLineToTable(string line, int numOfLines);
+  /** Contains the path to the oplsaa.sb file. */
+  string fileName;
 
-		/**
-		  Checks the format of the line being read in
-		  returns false if the format of the line is invalid
-		  @param line -  a line from the opls file
-        @return - Format code
-                  -1: Invalid Format
-                  1: Normal OPLS format
-                  2: Fourier Coefficent format
-		*/
-		int checkFormat(string line);
+  /**
+   * Given a line of input that specifies the data pertaining to a bond,
+   * stores the data in the bondDataMap.
+   * @param line A line of data from the OPLSAA.sb file.
+   */
+  void processBond(string line);
 
-		/**
-		  Logs all the Errors found in the OPLS file to the output log.
-		*/
-		void logErrors();
+  /**
+   * Given a line of input that specifies the data pertaining to an angle,
+   * stores the data in the angleDataMap.
+   * @param line A line of data from the OPLSAA.sb file.
+   */
+  void processAngle(string line);
 
-		/**
-		Returns an Atom struct based on the hashNum (1st col) in Z matrix file
-		The Atom struct has -1 for x,y,z and has the hashNum for an id.
-		sigma, epsilon, charges
-		@param hashNum -  the hash number (1st col) in Z matrix file
-        @return - the atom with that is the value to the hasNum key.
-		*/
-		Atom getAtom(string hashNum);
+  /**
+   * Given a line of input, stores the data in the pertinent map.
+   * @param line A line of data from the OPLSAA.sb file.
+   */
+  void processLine(string line);
 
-		/**
-		Returns the sigma value based on the hashNum (1st col) in Z matrix file
-		@param hashNum -  the hash number (1st col) in Z matrix file
-        @return - the sigma value of the atom that is the value associated with the hasNum key.
-		*/
-		Real getSigma(string hashNum);
+ public:
+  /** Constructor for SBScanner */
+  SBScanner();
 
-		/**
-		Returns the epsilon value based on the hashNum (1st col) in Z matrix file
-		@param hashNum - the hash number (1st col) in Z matrix file
-        @return - the epsilon value of the atom that is the value associated with the hashNum key.
-		*/
-		Real getEpsilon(string hashNum);
+  /** Destructor for SBScanner */
+  ~SBScanner();
 
-		/**
-		Returns the charge value based on the hashNum (1st col) in Z matrix file
-		@param hashNum -  the hash number (1st col) in Z matrix file
-        @return - the charge value of the atom that is the value associated with the hashNum key.
-		*/
-		Real getCharge(string hashNum);
+  /**
+   * Reads in OPLS.sb and stores the bond and angle data.
+   * @param fileName The path and name of the file to read from.
+   * @return - success code
+   *       0: successful
+   *       1: error
+   */
+  bool readInSB(string filename);
 
-		/**
-		Returns the V values value based on the hashNum (1st col) in Z matrix file
-		@param hashNum -  the hash number (1st col) in Z matrix file
-        @return - TODO
-		*/
-		Fourier getFourier(string hashNum);
+  /**
+   * Given a pair of atoms, returns the kBond between them.
+   * @param atom1 One of the atoms in the bond.
+   * @param atom2 The other atom in the bond.
+   * @return The force constant of the bond.
+   */
+  Real getKBond(string atom1, string atom2);
+
+  /**
+   * Given a pair of atoms, returns the eqBondDist between them.
+   * @param atom1 One of the atoms in the bond.
+   * @param atom2 The other atom in the bond.
+   * @return The equilibrium bond distance.
+   */
+  Real getEqBondDist(string atom1, string atom2);
+
+  /**
+   * Given three atoms, returns the kAngle of the angle that they form.
+   * @param endpoint1 The atom at one end of the angle.
+   * @param middleAtom The atom in the middle of the angle.
+   * @param endpoint2 The atom at the other end of the angle.
+   * @return The force constant of the angle.
+   */
+  Real getKAngle(string endpoint1, string middleAtom, string endpoint2);
+
+  /**
+   * Given three atoms, returns the eqAngle of the angle that they form.
+   * @param endpoint1 The atom at one end of the angle.
+   * @param middleAtom The atom in the middle of the angle.
+   * @param endpoint2 The atom at the other end of the angle.
+   * @return The equilibrium angle formed by the three atoms (in degrees).
+   */
+  Real getEqAngle(string endpoint1, string middleAtom, string endpoint2);
 
 };
 
+class ConfigScanner {
+ private:
+  /** The name of the simulation being run. */
+  string simName;
 
-class ZmatrixScanner
-{
-   private:
-      /**
-         The path to the Z-matrix file
-      */
-      string fileName;
-      /**
-        Opls_Scan object used to assign sigma, epsilon and charge values.
-      */
-      OplsScanner* oplsScanner;
-      /**
-        Vector that holds example molecules.
-      */
-      vector<Molecule> moleculePattern;
-      /**
-        Vector that holds the atoms contained in the molecule in the Z-matrix.
-      */
-      vector<Atom> atomVector;
-      /**
-        Vector that holds the bonds contained in the molecule in the Z-matrix.
-      */
-      vector<Bond> bondVector;
-      /**
-        Vector that holds the angles contained in the molecule in the Z-matrix.
-      */
-      vector<Angle> angleVector;
-      /**
-        Vector that holds the dihedrals contained in the molecule in the Z-matrix.
-      */
-      vector<Dihedral> dihedralVector;
-      /**
-        Vector of dummy atoms held seperately from the normal atoms.
-      */
-      vector<unsigned long> dummies;
-      /**
-        Global variable that determines if there are multiple molecules in a Z-matrix.
-      */
-      bool startNewMolecule;
-      /**
-        Global variable used to store the format id of the last line scanned.
-		  needed to read the bottom sections of the Z-matrix file.
-      */
-      int previousFormat;
+  /** The environment used in the simulation. */
+  Environment enviro;
 
-   public:
-      ZmatrixScanner(); // constructor
-      ~ZmatrixScanner();
+  /** The path to the configuration file to be read. */
+  string configPath;
 
-		/**
-          Scans in the z-matrix File calls sub-function parseLine
-          @param filename - the name/path of the z-matrix file
-		  @param scanner - points to the oplsScanner to get sigma, epsilon, and charge values from.
-          @return - success code
-                    0: Valid z-matrix path
-                    1: Invalid z-matrix path
-		*/
-        bool readInZmatrix(string filename, OplsScanner* scanner);
+  /** The number of step to run the simulation. */
+  long numOfSteps;
 
-		/**
-          Parses out a line from the zmatrix file and gets the atom from the OPLS hash
-          Creates structs for bond, angle, dihedral, if applicable
-          calls sub-function checkFormat()
-          @param line - a line from the zmatrix file
-          @param numOflines - number of lines previously read in, used for error output
-		*/
-        void parseLine(string line, int numOfLines);
+  /** The path to the opls file.  */
+  string oplsuaparPath;
 
-		/**
-          Checks the format of the line being read in
-          returns false if the format of the line is invalid
-          @param line -  a line from the zmatrix file
-          @param stringCount - number of strings in a line you're looking at
-          @return - Format code
-                    1: Base atom row listing
-                    2: TERZ line
-                    3: Geometry Variations
-                    4: Variable Bonds
-                    5: Additional Bonds
-                    6: Harmonic Constraints
-                    7: Variable Angles
-                    8: Additional Angles
-                    9: Variable Dihedrals
-                    10: Additional Dihedrals
-                    11: Domain Definitions
-                    -2: Final Blank Line
-                    -1: Invalid line format
-		*/
-        int checkFormat(string line);
+  /** The path to the Z-matrix file to be used in the simulation. */
+  string zmatrixPath;
 
-        /**
-		  Handles the additional stuff listed at the bottom of the Z-matrix file
-		  @param line -   a line from the zmatrix file
-		  @param cmdFormat- the int representing the format for which the line applies :see checkFormat
-		*/
-        void handleZAdditions(string line, int cmdFormat);
+  /** The path to the state file to be used. */
+  string statePath;
 
-        /**
-          Creates a vector containg the Hop distances of a molecule
-          for all hops that have a distance greater than 3.
-          @param molec - the molecule to check its bonds for valid hops
-          @return - returns a vector of hops needed for energy calculations
-        */
-        vector<Hop> calculateHops(Molecule molec);
+  /** The path to write the state output files. */
+  string stateOutputPath;
 
-        /**
-          Checks if the int item is contained in the vector
-          @param vect - the vector to search through
-          @param item - the item to search for
-          @return - true if the int is in the vector and false otherwise.
-        */
-        bool contains(vector<int> &vect, int item);
+  /** The path where to write the pdb output files. */
+  string pdbOutputPath;
 
-        /**
-          Returns the distance of the shortest path amongst bonds between two atoms
-          @param atom1 - the id of the starting atom
-          @param atom2 - the if of the ending atom
-          @param size - number of atoms in molecule
-          @param graph - a 2d array representing all the bonds in the molecule
-          @return - returns the number of bonds seperating atom1 and atom2.
-        */
-        int findHopDistance(int atom1,int atom2,int size, int **graph);
+  /** The nonbonded cutoff distance. */
+  long cutoff;
 
-        /**
-          Creates a 2d array representing all the bonds in the molecule
-          the array is filled with 1 or 0 for a bond or no bond between atoms
-          array is n*n where n is the number of atoms.
-          @param graph - a 2d array representing all the bonds in the molecule
-          @param molec - the molecule to check its bonds for valid hops
-        */
-        void buildAdjacencyMatrix(int **&graph, Molecule molec);
+  /** Used for detection of Zmatrix and State file paths in file */
+  bool isSafeToContinue;
 
+  /** Try the state file for pre-sim setup; fallback to ZMatrix */
+  bool useStatefileSetup;
 
-        /**
-          Creates a molecule(s)  based on a starting unique ID and the pattern specified
-          by the Z-matrix in the scan functions
-          @param startingID - first ID for the molecule being built
-          @return - vector of unique molecules that are copies of the molecules from the
-          Z-matrix file.
-        */
-        vector<Molecule> buildMolecule(int startingID);
+  /** Use the ZMatrix file unless state file is available */
+  bool useZMatrixSetup;
+
+  /** The name of the strategy to use */
+  string strategy;
+
+  void throwScanError(string message);
+  void parsePrimaryIndexDefinitions(string definitions);
+
+ public:
+  /**
+   * Default constructor that initializes the scanner to default values but
+   * does not read in any files yet.
+   */
+  ConfigScanner();
+
+  /**
+   * Reads in the config file located at config path given in the
+   * constructor.
+   */
+  bool readInConfig(string configpath);
+
+  /** @return the environment variable in this ConfigScanner */
+  Environment* getEnviro();
+
+  /** @return the path to the configuration file. */
+  string getConfigPath();
+
+  /** @return the number of steps to run the simulation. */
+  long getSteps();
+
+  /** @return the path to the opls file for the simulation. */
+  string getOplsusaparPath();
+
+  /** @return the path to the z-matrix file to be used in the simulation */
+  string getZmatrixPath();
+
+  /** @return the path to the state input file for the simulation. */
+  string getStatePath();
+
+  /** @return the path to the state output file for the simulation. */
+  string getStateOutputPath();
+
+  /** @return the path to the pdb output file(s) for the simulation. */
+  string getPdbOutputPath();
+
+  /** @return the simulation name */
+  string getSimulationName();
+
+  /** @return the simulation strategy string */
+  string getStrategy();
+
+  /** @returns the nonbonded cutoff in the simulation. */
+  long getcutoff();
+
+  /** @return the random seed used in the simulation.  */
+  unsigned int getrandomseed() { return enviro.randomseed; }
+
+  /**
+   * @return whether or not we should use the state file for setup, with
+   * preference over the zmatrix file
+   */
+  bool doSetupFromStateFile() {return useStatefileSetup;}
+
+  /** @return whether or not we should use the ZMatrix file for setup, in the
+   * event the state file isn't found
+   */
+  bool doSetupFromZMatrixFile() {return useZMatrixSetup;}
 };
 
 
-class StateScanner
-{
-  private:
-    std::string universal_filename;
-    void parsePrimaryIndexDefinitions(Environment* enviro, string definitions);
+class OplsScanner {
+ private:
+  /** Map of opls references */
+  map<string,Atom> oplsTable;
 
-  public:
-    StateScanner(std::string filename);
-    ~StateScanner();
+  /** Map of  the Fourier Coefficents stored */
+  map<string,Fourier> fourierTable;
 
-    /*
-      @param filename - the name of the state file
-      @return - the environment recorded in the state file.
-    */
-    Environment* readInEnvironment();
+  /** The path to the OPLS file. */
+  string fileName;
 
-    /**
-      @param sbScanner_in - points to the sbScanner holding various constants pertaining to bonds and angles.
-      @return - an array of molecules
-    */
-    vector<Molecule> readInMolecules();
+  /**
+   * Vector used to keep track of errors when lines in the OPLS file that
+   * don't match the correct format.
+   */
+  vector<int> errLines;
 
-    /**
-      @return - the starting step number in the state file
-    */
-    long readInStepNumber();
+  /**
+   * Vector used to keep track of errors when the hashes in the OPLS file
+   * that exist more than once.
+   */
+  vector<string> errHashes;
 
-    /**
-      expected input line:
-      "atom1 atom2 value [0|1]"
-      0 represents not variable
-      1 represents variable angle
+  /**
+   * Vector used to keep track of errors when the hashes in the fourier
+   * coefficent section of the OPLS file that exist more than once.
+   */
+  vector<string> errHashesFourier;
 
-      @param line - line containing information about the angle
-      @return - returns a bond
-    */
-    Angle getAngleFromLine(string line);
+ public:
+  /**
+   * Constrctor for the OplsScanner object.
+   * @param fileName - the path to the OPLS file
+   */
+   OplsScanner();
+   ~OplsScanner();
 
-    /**
-      input line is of the format:
-      "id x y z sigma epsilon"
-      @param line - the line from the state file that contains atom information.
-      @return - atom containing information from the line
-    */
-    Atom getAtomFromLine(string line);
+  /**
+   * Scans in the opls File calls sub-function addLineToTable
+   * @param filename - the name/path of the opls file
+   * @return - success code
+   *   0: successful
+   *   1: error
+   */
+  bool readInOpls(string filename);
 
-    /**
-      expected input line:
-      "atom1 atom2 distance [0|1]"
-      0 represents not variable
-      1 represents a variable bond
-      @param line - the line to be read.
-      @return - bond representing the information read from the line.
-    */
-    Bond getBondFromLine(string line);
+  /**
+   * Parses out a line from the opls file and gets (sigma, epsilon, charge)
+   * adds an entry to the map at the hash number position, calls sub-function
+   * checkFormat()
+   * @param line - a line from the opls file
+   * @param numOflines - number of lines previously read in, used for error
+   * output
+   */
+  void addLineToTable(string line, int numOfLines);
 
-    /**
-      expected input line:
-      "atom1 atom2 value [0|1]"
-      0 represents not variable
-      1 represents variable dihedral
+  /**
+   * Checks the format of the line being read in
+   * returns false if the format of the line is invalid
+   * @param line -  a line from the opls file
+   * @return - Format code
+   *   -1: Invalid Format
+   *    1: Normal OPLS format
+   *    2: Fourier Coefficent format
+   */
+  int checkFormat(string line);
 
-      @param line - line containing information about the dihedral
-      @return - returns the dihedral represented on the line
-    */
-    Dihedral getDihedralFromLine(string line);
+  /** Logs all the Errors found in the OPLS file to the output log. */
+  void logErrors();
 
-    /**
-      input line is of the format:
-      "x y z numOfAtoms"
-      @param line - the line to be parsed
-      @return - Environment read from the line
-    */
-    Environment* getEnvironmentFromLine(string line);
+  /**
+   * Returns an Atom struct based on the hashNum (1st col) in Z matrix file.
+   * The Atom struct has -1 for x,y,z and has the hashNum for an id.
+   * sigma, epsilon, charges
+   * @param hashNum -  the hash number (1st col) in Z matrix file
+   * @return - the atom with that is the value to the hasNum key.
+   */
+  Atom getAtom(string hashNum);
 
-    /**
-      expected input line:
-      "atom1 atom2 hopDistance"
+  /**
+   * Returns the sigma value based on the hashNum (1st col) in Z matrix file
+   * @param hashNum -  the hash number (1st col) in Z matrix file
+   * @return the sigma value of the atom that is the value associated with
+   * the hasNum key.
+   */
+  Real getSigma(string hashNum);
 
-      @param line - line containing information about the hop
-      @return - a hop represented by the information on the line.
-    */
-    Hop getHopFromLine(string line);
+  /**
+   * Returns the epsilon value based on the hashNum (1st col) in Z matrix
+   * file.
+   * @param hashNum - the hash number (1st col) in Z matrix file
+   * @return - the epsilon value of the atom that is the value associated
+   * with the hashNum key.
+  */
+  Real getEpsilon(string hashNum);
 
-    /**
-    	Once the state file has been read in,
-    	passes the Environment for pre-box setup.
-    	[If you attempt to get the Environment before
-    	the state file is successfully read in, passes NULL].
-    */
+  /**
+   * Returns the charge value based on the hashNum (1st col) in Z matrix file
+   * @param hashNum -  the hash number (1st col) in Z matrix file
+   * @return - the charge value of the atom that is the value associated with
+   * the hashNum key.
+   */
+  Real getCharge(string hashNum);
+
+  /**
+   * Returns the V values value based on the hashNum (1st col) in Z matrix
+   * file
+   * @param hashNum -  the hash number (1st col) in Z matrix file
+   * @return - TODO
+   */
+  Fourier getFourier(string hashNum);
+};
 
 
-    /**
-    	Once the state file has been read in,
-    	passes the Molecule for pre-box setup.
-    	[If you attempt to get the Molecule before
-    	the state file is successfully read in, passes NULL].
-    	@param: [None]
-    	@return: a singular molecule for the environment
-    */
+class ZmatrixScanner {
+ private:
+  /** The path to the Z-matrix file */
+  string fileName;
 
-    /**
-      @param environment - the environment state
-      @param molecules - array of molecules to be printed out
-      @param numOfMolecules - the number of molecules to be written out
-      @param fileName - the name of the file to be written
-			@param atomCoords - the coordinates of the atoms in the box.
-    */
-    void outputState(Environment *environment, Molecule *molecules, int numOfMolecules, int step, string filename, Real** atomCoords);
+  /** Opls_Scan object used to assign sigma, epsilon and charge values. */
+  OplsScanner* oplsScanner;
+
+  /** Vector that holds example molecules. */
+  vector<Molecule> moleculePattern;
+
+  /** Vector that holds the atoms contained in the molecule in the Z-matrix */
+  vector<Atom> atomVector;
+
+  /** Vector that holds the bonds contained in the molecule in the Z-matrix */
+  vector<Bond> bondVector;
+  /**
+   * Vector that holds the angles contained in the molecule in the Z-matrix.
+   */
+  vector<Angle> angleVector;
+
+  /**
+   * Vector that holds the dihedrals contained in the molecule in the Z-matrix
+   */
+  vector<Dihedral> dihedralVector;
+
+  /** Vector of dummy atoms held seperately from the normal atoms. */
+  vector<unsigned long> dummies;
+
+  /**
+   * Global variable that determines if there are multiple molecules in a
+   * Z-matrix.
+   */
+  bool startNewMolecule;
+
+  /**
+   * Global variable used to store the format id of the last line scanned.
+   * Needed to read the bottom sections of the Z-matrix file.
+   */
+  int previousFormat;
+
+ public:
+  ZmatrixScanner(); // constructor
+  ~ZmatrixScanner();
+
+  /**
+   * Scans in the z-matrix File calls sub-function parseLine
+   * @param filename - the name/path of the z-matrix file
+   * @param scanner - points to the oplsScanner to get sigma, epsilon, and
+   * charge values from.
+   * @return - success code
+   *   0: Valid z-matrix path
+   *   1: Invalid z-matrix path
+   */
+  bool readInZmatrix(string filename, OplsScanner* scanner);
+
+  /**
+   * Parses out a line from the zmatrix file and gets the atom from the OPLS
+   * hash
+   * Creates structs for bond, angle, dihedral, if applicable
+   * calls sub-function checkFormat()
+   * @param line - a line from the zmatrix file
+   * @param numOflines - number of lines previously read in, used for error
+   * output
+   */
+  void parseLine(string line, int numOfLines);
+
+  /**
+   * Checks the format of the line being read in
+   * returns false if the format of the line is invalid
+   * @param line -  a line from the zmatrix file
+   * @param stringCount - number of strings in a line you're looking at
+   * @return - Format code
+   *   1: Base atom row listing
+   *   2: TERZ line
+   *   3: Geometry Variations
+   *   4: Variable Bonds
+   *   5: Additional Bonds
+   *   6: Harmonic Constraints
+   *   7: Variable Angles
+   *   8: Additional Angles
+   *   9: Variable Dihedrals
+   *   10: Additional Dihedrals
+   *   11: Domain Definitions
+   *   -2: Final Blank Line
+   *   -1: Invalid line format
+   */
+  int checkFormat(string line);
+
+  /**
+   * Handles the additional stuff listed at the bottom of the Z-matrix file
+   * @param line -   a line from the zmatrix file
+   * @param cmdFormat- the int representing the format for which the line
+   * applies :see checkFormat
+   */
+  void handleZAdditions(string line, int cmdFormat);
+
+  /**
+   * Creates a vector containg the Hop distances of a molecule
+   * for all hops that have a distance greater than 3.
+   * @param molec - the molecule to check its bonds for valid hops
+   * @return - returns a vector of hops needed for energy calculations
+   */
+  vector<Hop> calculateHops(Molecule molec);
+
+  /**
+   * Checks if the int item is contained in the vector
+   * @param vect - the vector to search through
+   * @param item - the item to search for
+   * @return - true if the int is in the vector and false otherwise.
+   */
+  bool contains(vector<int> &vect, int item);
+
+  /**
+   * Returns the distance of the shortest path amongst bonds between two atoms
+   * @param atom1 - the id of the starting atom
+   * @param atom2 - the if of the ending atom
+   * @param size - number of atoms in molecule
+   * @param graph - a 2d array representing all the bonds in the molecule
+   * @return - returns the number of bonds seperating atom1 and atom2.
+   */
+  int findHopDistance(int atom1,int atom2,int size, int **graph);
+
+  /**
+   * Creates a 2d array representing all the bonds in the molecule
+   * the array is filled with 1 or 0 for a bond or no bond between atoms
+   * array is n*n where n is the number of atoms.
+   * @param graph - a 2d array representing all the bonds in the molecule
+   * @param molec - the molecule to check its bonds for valid hops
+   */
+  void buildAdjacencyMatrix(int **&graph, Molecule molec);
+
+
+  /**
+   * Creates a molecule(s)  based on a starting unique ID and the pattern
+   * specified by the Z-matrix in the scan functions
+   * @param startingID - first ID for the molecule being built
+   * @return - vector of unique molecules that are copies of the molecules
+   * from the
+   * Z-matrix file.
+   */
+  vector<Molecule> buildMolecule(int startingID);
+};
+
+
+class StateScanner {
+ private:
+  std::string universal_filename;
+  void parsePrimaryIndexDefinitions(Environment* enviro, string definitions);
+
+ public:
+  StateScanner(std::string filename);
+  ~StateScanner();
+
+  /**
+   * @param filename - the name of the state file
+   * @return - the environment recorded in the state file.
+   */
+  Environment* readInEnvironment();
+
+  /**
+   * @param sbScanner_in - points to the sbScanner holding various constants
+   * pertaining to bonds and angles.
+   * @return - an array of molecules
+   */
+  vector<Molecule> readInMolecules();
+
+  /** @return the starting step number in the state file */
+  long readInStepNumber();
+
+  /**
+   * expected input line:
+   * "atom1 atom2 value [0|1]"
+   * 0 represents not variable
+   * 1 represents variable angle
+   *
+   * @param line - line containing information about the angle
+   * @return - returns a bond
+   */
+  Angle getAngleFromLine(string line);
+
+  /**
+   * input line is of the format:
+   * "id x y z sigma epsilon"
+   * @param line - the line from the state file that contains atom information
+   * @return - atom containing information from the line
+   */
+  Atom getAtomFromLine(string line);
+
+  /**
+   * expected input line:
+   * "atom1 atom2 distance [0|1]"
+   * 0 represents not variable
+   * 1 represents a variable bond
+   * @param line - the line to be read.
+   * @return - bond representing the information read from the line.
+   */
+  Bond getBondFromLine(string line);
+
+  /**
+   * expected input line:
+   * "atom1 atom2 value [0|1]"
+   * 0 represents not variable
+   * 1 represents variable dihedral
+   *
+   * @param line - line containing information about the dihedral
+   * @return - returns the dihedral represented on the line
+   */
+  Dihedral getDihedralFromLine(string line);
+
+  /**
+   * input line is of the format:
+   * "x y z numOfAtoms"
+   * @param line - the line to be parsed
+   * @return - Environment read from the line
+   */
+  Environment* getEnvironmentFromLine(string line);
+
+  /**
+   * expected input line:
+   * "atom1 atom2 hopDistance"
+   *
+   * @param line - line containing information about the hop
+   * @return - a hop represented by the information on the line.
+   */
+  Hop getHopFromLine(string line);
+
+  /**
+   * Once the state file has been read in,
+   * passes the Environment for pre-box setup.
+   * [If you attempt to get the Environment before
+   * the state file is successfully read in, passes NULL].
+   */
+
+
+  /**
+   * Once the state file has been read in,
+   * passes the Molecule for pre-box setup.
+   * [If you attempt to get the Molecule before
+   * the state file is successfully read in, passes NULL].
+   * @param: [None]
+   * @return: a singular molecule for the environment
+   */
+
+  /**
+   * @param environment - the environment state
+   * @param molecules - array of molecules to be printed out
+   * @param numOfMolecules - the number of molecules to be written out
+   * @param fileName - the name of the file to be written
+   * @param atomCoords - the coordinates of the atoms in the box.
+   */
+  void outputState(Environment *environment, Molecule *molecules,
+                   int numOfMolecules, int step, string filename,
+                   Real** atomCoords);
 };
 
 /**
-*	Properly sets up the box for use in the simulation.
-*	Builds the environment based on either the configuration file or the state file,
-*	as determined elsewhere.
-*
-* @param: inputPath: the path to either the config file OR the state file, depending on logic path chosen
-* @param: inputType: Whether we are running from the config file + zmatrix combo, or from the state file
-* @param: box: the generic box into which all the environment information
-*		is to be stored; can be modified as necessary for serial or parallel use later.
-* @param: startStep:
-* @param: steps:
-*
-* @returns: returns TRUE if completed successfully, or FALSE if there was a show-stopping error
-*		for which you should do halt the simulation
-*/
-bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep, long* steps);
+ * Properly sets up the box for use in the simulation.
+ * Builds the environment based on either the configuration file or the state
+ * file, as determined elsewhere.
+ *
+ * @param: inputPath: the path to either the config file OR the state file,
+ * depending on logic path chosen
+ * @param: inputType: Whether we are running from the config file + zmatrix
+ * combo, or from the state file
+ * @param: box: the generic box into which all the environment information
+ * is to be stored; can be modified as necessary for serial or parallel use
+ * later.
+ * @param: startStep:
+ * @param: steps:
+ *
+ * @returns true if completed successfully, or fals if there was a
+ * show-stopping error for which you should halt the simulation
+ */
+bool loadBoxData(SimulationArgs& simArgs, Box* box, long* startStep,
+                 long* steps);
 
 
-/*************************
-*Builds data for the simulation box/environment from the Zmatrix and config files, if
-* so desired. Note: this doesn't fully enable the box to be used for the simulation; the geometry
-* information must be set up. There's a call to generatefcc box at the end of the method,
-* at which point the box will actually be "generated"/ready.
-*
-* @param: enviro: the environment stored in the configuration file
-* @param: molecVec: the array of molecules, partly created from the Zmatrix file
-* @param: box: the box in which all the data is to be stored and the environment set up
-* @param: sb_scanner: used to read in from data from oplsaa.sb
-*
-* @return: returns TRUE if completed successfully, or FALSE if there was a show-stopping error
-*		for which you should do halt the simulation
-*/
-bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box, SBScanner &sb_scanner);
+/**
+ * Builds data for the simulation box/environment from the Zmatrix and config
+ * files, if so desired. Note: this doesn't fully enable the box to be used
+ * for the simulation; the geometry information must be set up. There's a call
+ * to generatefcc box at the end of the method, at which point the box will
+ * actually be "generated"/ready.
+ *
+ * @param enviro: the environment stored in the configuration file
+ * @param molecVec: the array of molecules, partly created from the Zmatrix
+ * file
+ * @param box: the box in which all the data is to be stored and the
+ * environment set up
+ * @param sb_scanner: used to read in from data from oplsaa.sb
+ *
+ * @return true if completed successfully, or fals if there was a
+ * show-stopping error for which you should halt the simulation
+ */
+bool buildBoxData(Environment* enviro, vector<Molecule>& molecVec, Box* box,
+                  SBScanner &sb_scanner);
 
-/*************************
-*	Uses data from a given state file to reconstruct a box/environment, as the box looked
-* at the time of the statefile's capture during a prior simulation run.
-*	Includes geometry information, etc, so the box will be ready for use in the current
-* simulation immediately after the data has been copied over to the box.
-*
-* @param: enviro: the Environment data from the statefile
-* @param: molecVec: the vector array of molecules, copied from the statefile
-* @param: box: the box for which data will be built, into which the data will go
-*
-* @return: returns TRUE if completed successfully, or FALSE if there was a show-stopping error
-*		for which you should do halt the simulation
-*/
-bool fillBoxData(Environment* enviro, vector<Molecule>& moleVec, Box* box, SBScanner& sb_scanner);
+/**
+ * Uses data from a given state file to reconstruct a box/environment, as the
+ * box looked * at the time of the statefile's capture during a prior
+ * simulation run. Includes geometry information, etc, so the box will be
+ * ready for use in the current * simulation immediately after the data has
+ * been copied over to the box.
+ *
+ * @param enviro: the Environment data from the statefile
+ * @param molecVec: the vector array of molecules, copied from the statefile
+ * @param box: the box for which data will be built, into which the data will
+ * go
+ *
+ * @return: returns TRUE if completed successfully, or FALSE if there was a
+ * show-stopping error for which you should do halt the simulation
+ */
+bool fillBoxData(Environment* enviro, vector<Molecule>& moleVec, Box* box,
+                 SBScanner& sb_scanner);
 
-/*************************
-*	Once the box has been filled with environment data, takes the data and
-*	sets up the geometry and other aspects necessary to successfully run a simulation.
-* Data must be loaded by either buildBoxData or fillBoxData, depending on if you are
-* loading a clean simulation, or loading from the state file.
-*
-* @param: box: the box to be used for simulation, with all data pre-loaded
-*
-*	@return: returns TRUE if completed successfully, or FALSE if there was a show-stopping error
-*		for which you should do halt the simulation
-*/
+/**
+ * Once the box has been filled with environment data, takes the data and sets
+ * up the geometry and other aspects necessary to successfully run a
+ * simulation.
+ * Data must be loaded by either buildBoxData or fillBoxData, depending on if
+ * you are loading a clean simulation, or loading from the state file.
+ *
+ * @param: box: the box to be used for simulation, with all data pre-loaded
+ * @return true if completed successfully, or false if there was a
+ * show-stopping error for which you should halt the simulation
+ */
 bool generatefccBox(Box* box);
 
-/*************************
-*This method allows for writing to a given log file, with some measure of automation.
-* These functions are namespace-less and class-less.
-* Said string contains almost all of the text you wish to be written to the file.
-* Opening and closing of the file will be done on the fly, and a closed file should be guaranteed once this method reaches its end.
-* If stringstream is needed, you may call the overloaded version below, which relies on this version of the method.
-*@param: text: the text to be written to the output file. Type: string.
-*@param: stamp: under which category we log this text: start of simulation [START], end of simulation [END],
-*		error while handling the OPLS files [OPLS] Zmatrix files [Z_MATRIX] or geometric config files [GEO], or generic [DEFAULT].
-*
-*@returns: [none]
-*/
+/**
+ * This method allows for writing to a given log file, with some measure of
+ * automation.
+ * These functions are namespace-less and class-less.
+ * Said string contains almost all of the text you wish to be written to the
+ * file.
+ * Opening and closing of the file will be done on the fly, and a closed file
+ * should be guaranteed once this method reaches its end.
+ * If stringstream is needed, you may call the overloaded version below, which
+ * relies on this version of the method.
+ *
+ * @param text: the text to be written to the output file. Type: string.
+ * @param stamp: under which category we log this text: start of simulation
+ * [START], end of simulation [END], error while handling the OPLS files
+ * [OPLS] Zmatrix files [Z_MATRIX] or geometric config files [GEO], or generic
+ * [DEFAULT].
+ */
 void writeToLog(string text,int stamp);
 
 /**
-*This method allows for writing to a given log file, with some measure of automation
-* This overloaded version allows for a stringstream, instead of a normal string, to be input.
-* Said string contains almost all of the text you wish to be written to the file.
-* Opening and closing of the file will be done on the fly, and should be guaranteed once this method reaches its end.
-*@param: ss: the text to be written to the output file. Type: Reference to a Stringsteam
-*@param: stamp: under which category we log this text: start of simulation [START], end of simulation [END],
-*		error while handling the OPLS files [OPLS] Zmatrix files [Z_MATRIX] or geometric config files [GEO], or generic [DEFAULT].
-*
-*@returns: [none]
-*/
+ * This method allows for writing to a given log file, with some measure of
+ * automation
+ * This overloaded version allows for a stringstream, instead of a normal
+ * string, to be input.
+ * Said string contains almost all of the text you wish to be written to the
+ * file.
+ * Opening and closing of the file will be done on the fly, and should be
+ * guaranteed once this method reaches its end.
+ *
+ * @param: ss: the text to be written to the output file. Type: Reference to a
+ * Stringsteam
+ * @param: stamp: under which category we log this text: start of simulation
+ * [START], end of simulation [END], error while handling the OPLS files
+ * [OPLS] Zmatrix files [Z_MATRIX] or geometric config files [GEO], or generic
+ * [DEFAULT].
+ */
 void writeToLog(stringstream& ss, int stamp);
 
 std::string& rtrim(std::string& s);

--- a/test/unittests/ConfigurationTest.config
+++ b/test/unittests/ConfigurationTest.config
@@ -1,0 +1,32 @@
+# Size of periodic box
+x=10.342
+y=1234.45
+z=100.3
+# Temperature
+temp=293
+# Max translation
+max-translation=.5
+# Number of steps
+steps=10000
+# Number of molecues
+molecules=500
+# Path to opla.par file
+opla.par=path/to/opla.par/file
+# Path to z matrix file
+z-matrix=path/to/zMatrix/file
+# Path to state input
+state-input=path/to/state/input
+# Path to state output
+state-output=path/to/State/output
+# Pdb output path
+pdb-output=path/to/pdb/output
+# Cutoff distance
+cutoff=25
+# Max rotation
+max-rotation=15
+# Random seed input
+random-seed=12345
+# Primary atom index
+primary-atom=1
+# Simulation name
+sim-name=MyTestSimulation

--- a/test/unittests/ConfigurationTest.config
+++ b/test/unittests/ConfigurationTest.config
@@ -30,3 +30,5 @@ random-seed=12345
 primary-atom=1
 # Simulation name
 sim-name=MyTestSimulation
+# Energy calculation strategy
+strategy=energy-strategy

--- a/test/unittests/ConfigurationTest.cpp
+++ b/test/unittests/ConfigurationTest.cpp
@@ -1,4 +1,3 @@
-
 #include "Metropolis/Utilities/FileUtilities.h"
 #include "gtest/gtest.h"
 
@@ -8,58 +7,59 @@
  * The ConfigScanner reads .config files and sets up the simulation based on
  * those values. Test that those values are properly read and processed.
  */
-TEST(IOTests, ConfigScan)
-{
-	const double ERROR_MARGIN = 0.0001;
+TEST (IOTests, ConfigScan) {
+  const double ERROR_MARGIN = 0.0001;
 
-	// Find the MCGPU project path
-    size_t size = 4096;
-    char *path = (char*) malloc(size);
-    path = getcwd(path, size);
-    std::string directory(path);
-    std::string mc ("MCGPU");
-    std::size_t found = directory.find(mc);
+  // Find the MCGPU project path
+  size_t size = 4096;
+  char *path = (char*) malloc(size);
+  path = getcwd(path, size);
+  std::string directory(path);
+  std::string mc ("MCGPU");
+  std::size_t found = directory.find(mc);
 
-    if (found != std::string::npos) {
-        directory = directory.substr(0,found+6);
-    }
-    std::string MCGPU = directory;
+  if (found != std::string::npos) {
+      directory = directory.substr(0,found+6);
+  }
+  std::string MCGPU = directory;
 
-    string configPath = MCGPU;
-    configPath.append("test/unittests/ConfigurationTest.config");
-    string oplsPath = "path/to/opla.par/file";
-    string zMatrixPath = "path/to/zMatrix/file";
-    string stateInputPath = "path/to/state/input";
-    string stateOutputPath = "path/to/State/output";
-    string pdbOutputPath = "path/to/pdb/output";
-	string simName = "MyTestSimulation";
-    ConfigScanner cs;
-    cs.readInConfig(configPath);
+  string configPath = MCGPU;
+  configPath.append("test/unittests/ConfigurationTest.config");
+  string oplsPath = "path/to/opla.par/file";
+  string zMatrixPath = "path/to/zMatrix/file";
+  string stateInputPath = "path/to/state/input";
+  string stateOutputPath = "path/to/State/output";
+  string pdbOutputPath = "path/to/pdb/output";
+  string simName = "MyTestSimulation";
+  string strategy = "energy-strategy";
+  ConfigScanner cs;
+  cs.readInConfig(configPath);
 
-    // Test various path elements
-	EXPECT_EQ(configPath, cs.getConfigPath());
-	EXPECT_EQ(oplsPath, cs.getOplsusaparPath());
-	EXPECT_EQ(zMatrixPath, cs.getZmatrixPath());
-	EXPECT_EQ(stateInputPath, cs.getStatePath());
-	EXPECT_EQ(stateOutputPath, cs.getStateOutputPath());
-	EXPECT_EQ(pdbOutputPath, cs.getPdbOutputPath());
-	EXPECT_EQ(simName, cs.getSimulationName());
+  // Test various path elements
+  EXPECT_EQ(configPath, cs.getConfigPath());
+  EXPECT_EQ(oplsPath, cs.getOplsusaparPath());
+  EXPECT_EQ(zMatrixPath, cs.getZmatrixPath());
+  EXPECT_EQ(stateInputPath, cs.getStatePath());
+  EXPECT_EQ(stateOutputPath, cs.getStateOutputPath());
+  EXPECT_EQ(pdbOutputPath, cs.getPdbOutputPath());
+  EXPECT_EQ(simName, cs.getSimulationName());
+  EXPECT_EQ(strategy, cs.getStrategy());
 
-    // Test box dimensions
-    double x = 10.342;
-    double y = 1234.45;
-    double z = 100.3;
-    double temperature = 293;
-    double maxTranslation = .5;
-    int numberOfSteps = 10000;
-    int numberOfMolecules = 500;
+  // Test box dimensions
+  double x = 10.342;
+  double y = 1234.45;
+  double z = 100.3;
+  double temperature = 293;
+  double maxTranslation = .5;
+  int numberOfSteps = 10000;
+  int numberOfMolecules = 500;
 
-    Environment* enviro = cs.getEnviro();
-	EXPECT_NEAR(x, enviro->x, ERROR_MARGIN);
-	EXPECT_NEAR(y, enviro->y, ERROR_MARGIN);
-	EXPECT_NEAR(z, enviro->z, ERROR_MARGIN);
-	EXPECT_NEAR(maxTranslation, enviro->maxTranslation, ERROR_MARGIN);
-	EXPECT_NEAR(numberOfMolecules, enviro->numOfMolecules, ERROR_MARGIN);
-	EXPECT_NEAR(temperature, enviro->temp, ERROR_MARGIN);
-	EXPECT_NEAR(numberOfSteps, cs.getSteps(), ERROR_MARGIN);
+  Environment* enviro = cs.getEnviro();
+  EXPECT_NEAR(x, enviro->x, ERROR_MARGIN);
+  EXPECT_NEAR(y, enviro->y, ERROR_MARGIN);
+  EXPECT_NEAR(z, enviro->z, ERROR_MARGIN);
+  EXPECT_NEAR(maxTranslation, enviro->maxTranslation, ERROR_MARGIN);
+  EXPECT_NEAR(numberOfMolecules, enviro->numOfMolecules, ERROR_MARGIN);
+  EXPECT_NEAR(temperature, enviro->temp, ERROR_MARGIN);
+  EXPECT_NEAR(numberOfSteps, cs.getSteps(), ERROR_MARGIN);
 }


### PR DESCRIPTION
Includes @joverbey 's Proximity Matrix implementation

**Changes**
  - New proximity matrix strategy for calculating system energy
  - New command-line argument (`--strategy` and `-S`) for specifying strategy
    - Options are "brute-force" and "proximity-matrix"
  - New config file option for strategy (`strategy`)
  - "Minor" cleanup: 80 character line length and 2 space indentation

**Note:** functions duplicated between original `ProximityMatrixCalcs` and `BruteForceCalcs` namespaces were refactored into `SimCalcs` namespace, with the exception of `calcMoleculeInteractionEnergy()`. Since it is an `acc vector` routine, it could not be called from another namespace, so it had to be duplicated. Hopefully this functionality will be supported in future versions of PGCC.