### PR TITLE
Add multiple solvent/primary indexes test cases

### DIFF
--- a/test/unittests/MultipleSolvents/meoh-t3pTests/meoh-t3p.z
+++ b/test/unittests/MultipleSolvents/meoh-t3pTests/meoh-t3p.z
@@ -1,0 +1,21 @@
+        Methanol                                        
+   1 O    154  154    0    0.000000   0    0.000000   0    0.000000        0    
+   2 H    155  155    1    0.945698   0    0.000000   0    0.000000        0    
+   3 C    157  157    1    1.411870   2  108.989752   0    0.000000        0    
+   4 H    156  156    3    1.090450   1  110.239001   2  179.999996        0    
+   5 H    156  156    3    1.090404   1  110.549523   4  119.850735        0    
+   6 H    156  156    3    1.090404   1  110.549526   4  240.149263        0    
+TERZ
+   7 O    111  111    0     .000000   0     .000000   0     .000000        0    
+   8 H    112  112    7     .957200   0     .000000   0     .000000        0    
+   9 H    112  112    7     .957200   8  104.520000   1    1.017000        0
+                    Geometry Variations follow                                  
+                    Variable Bonds follow         (I4 or I4-I4)                 
+                    Additional Bonds follow       (2I4)                         
+                    Harmonic Constraints follow                                 
+                    Variable Bond Angles follow   (I4 or I4-I4)                 
+                    Additional Bond Angles follow (3I4)                         
+                    Variable Dihedrals follow     (3I4,F12.6)                   
+                    Additional Dihedrals follow   (6I4)                         
+                    Domain Definitions follow     (4I4)                         
+                    Final blank line                                            

--- a/test/unittests/meoh-t3pTest.cpp
+++ b/test/unittests/meoh-t3pTest.cpp
@@ -1,0 +1,93 @@
+#include "Applications/Application.h"
+#include "gtest/gtest.h"
+#include "TestUtil.h"
+
+void createMeohT3PConfigFile(std::string MCGPU, std::string fileName,
+                            double boxSize, int molecules) {
+  ConfigFileData settings = ConfigFileData(
+      boxSize, boxSize, boxSize, 298.15, 0.12, 100000, molecules,
+      "resources/bossFiles/oplsaa.par",
+      "test/unittests/MultipleSolvents/meoh-t3pTests/meoh-t3p.z",
+      "test/unittests/MultipleSolvents/meoh-t3pTests", 11.0, 12.0, 12345);
+  createConfigFile(MCGPU, fileName, "[1],[1]", settings);
+}
+
+std::string buildMeohT3PCommand(std::string MCGPU, std::string configFile,
+                               std::string outputName, bool series,
+                               bool neighborlist, bool errorExpected) {
+  return buildCommand(MCGPU, configFile, outputName, series, neighborlist,
+                      errorExpected,
+                      "test/unittests/MultipleSolvents/meoh-t3pTests");
+}
+
+// Test meoh-t3p with 256 molecules
+TEST(meoht3pTest, mol256) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p256";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 23.7856, 256);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             true, false, false).c_str());
+  double expected = -2007.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}
+
+// Test meoh-t3p with 256 molecules on the GPU
+TEST(meoht3pTest, mol256_GPU) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p256";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 23.7856, 256);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             false, false, false).c_str());
+  double expected = -2007.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}
+
+// Test meoh-t3p with 500 molecules
+TEST(meoht3pTest, mol500) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p500";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 32.91, 500);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             true, false, false).c_str());
+  double expected = -3148.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}
+
+// Test meoh-t3p with 500 molecules on the GPU
+TEST(meoht3pTest, mol500_GPU) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p500";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 32.91, 500);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             false, false, false).c_str());
+  double expected = -3148.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}
+
+// Test meoh-t3p with 8788 molecules
+TEST(meoht3pTest, mol8788) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p8788";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 85.57, 8788);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             true, false, false).c_str());
+  double expected = -13219.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}
+
+// Test meoh-t3p with 8788 molecules on the GPU
+TEST(meoht3pTest, mol8788_GPU) {
+  std::string MCGPU = getMCGPU_path();
+  std::string testName = "meoh-t3p8788";
+  createMeohT3PConfigFile(MCGPU, testName + ".config", 85.57, 8788);
+  system(buildMeohT3PCommand(MCGPU, testName + ".config", testName,
+                             false, false, false).c_str());
+  double expected = -13219.0;
+  double energyResult = getEnergyResult(MCGPU, testName + ".results");
+  EXPECT_NEAR(expected, energyResult, 100);
+}


### PR DESCRIPTION
Add test cases for multiple solvent and multiple primary indexes with 256, 500, and 8788 molecules. Cases added for both serial and parallel calculations.

**Note:** expected energy levels taken from values produced by running the simulation with the code already in master. 