### PR TITLE
Add timeit.sh (shell script to compute and display runtimes)

### DIFF
--- a/timeit.sh
+++ b/timeit.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# timeit.sh -- Times various MCGPU strategies on a couple of sample input files.
+#
+
+# Directory containing test files
+DIR=resources/exampleFiles
+# Test files on which to compute timings
+TESTFILES="indole4000.config meoh8788.config"
+#TESTFILES="indole267.config meoh500.config"
+
+function run_test {
+	name=$1
+	args=$2
+
+	printf '%30s' "$name"
+	printf '    '
+	for file in $TESTFILES; do
+		runtime=`bin/metrosim $args "$DIR/$file" | grep 'Run Time:' | sed -e 's/[^0-9.]//g'`
+		printf '%20.04f' $runtime
+		printf '    '
+	done
+	printf '\n'
+}
+
+echo 'MCGPU will be run on each of the files listed below, once per test.'
+echo 'Each run may take several minutes.  Please be patient.'
+echo 'Runtimes are in seconds.'
+echo ''
+
+# Display headers (config filenames)
+printf '%30s' ''
+printf '    '
+for file in $TESTFILES
+do
+	printf '%20s' "$file"
+	printf '    '
+done
+printf '\n'
+
+# Display separators (-------)
+printf '%30s' ''
+printf '    '
+for file in $TESTFILES
+do
+	printf '%20s' '--------------------'
+	printf '    '
+done
+printf '\n'
+
+# Now run tests and display runtimes
+run_test 'Parallel, Proximity Matrix:   ' '-p -S proximity-matrix'
+run_test 'Parallel, Brute Force:        ' '-p -S brute-force'
+run_test 'Serial, Proximity Matrix:     ' '-s -S proximity-matrix'
+run_test 'Serial, Brute Force:          ' '-s -S brute-force'
+
+exit 0


### PR DESCRIPTION
This shell script runs MCGPU on a couple of test files and displays the runtimes in a table (for comparison).  Currently, the output is something like this (times are from the Xeon/Tesla K40 in our lab):
```
MCGPU will be run on each of the files listed below, once per test.
Each run may take several minutes.  Please be patient.
Runtimes are in seconds.

                                     indole4000.config         meoh8788.config    
                                  --------------------    --------------------    
Parallel, Proximity Matrix:                    62.3300                103.4600    
Parallel, Brute Force:                        137.0500                259.8100    
Serial, Proximity Matrix:                     137.7800                 71.2400    
Serial, Brute Force:                          137.6600                 78.4400    
```