### PR TITLE
Update Makefile and demo_script.txt to run on DMC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ endif
 
 # Flags for linking metrosim with the PGI compiler.
 ifeq ($(CC),pgc++)
-	LinkFlags := -lgomp -acc -ta=nvidia -Minfo=accel
+	LinkFlags := -acc -ta=nvidia -Minfo=accel
 else
 	LinkFlags := -lgomp
 endif

--- a/demo_script.txt
+++ b/demo_script.txt
@@ -1,4 +1,3 @@
 #!/bin/sh
 source /opt/asn/etc/asn-bash-profiles-special/modules.sh
-module load cuda/4.2
-./bin/parallelExample bin/demoConfiguration.txt
+bin/metrosim resources/exampleFiles/indole267.config


### PR DESCRIPTION
This PR:
* updates the Makefile: there is no need to link against the GNU OpenMP library when using pgc++.
* updates demo_script.txt for DMC (```run_gpu demo_script.txt```)